### PR TITLE
Add Game of the Year page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ jspm_packages
 .node_repl_history
 .next
 .vercel
+.env*.local

--- a/app/game-of-the-year/GameDisplay.tsx
+++ b/app/game-of-the-year/GameDisplay.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { classNames } from "../../lib/util";
+
+interface Game {
+  year: number;
+  title: string;
+  imageUrl?: string | null;
+}
+
+interface GameDisplayProps {
+  game: Game;
+  allGames: { year: number; title: string }[];
+}
+
+export default function GameDisplay({ game, allGames }: GameDisplayProps) {
+  return (
+    <>
+      <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 justify-center mb-6">
+        {allGames.map((g) => (
+          <Link
+            key={g.year}
+            href={`/game-of-the-year/${g.year}`}
+            prefetch={true}
+            className={classNames(
+              "px-3 py-2 rounded border inline-block text-center transition-colors duration-150",
+              game.year === g.year
+                ? "bg-indigo-600 text-white"
+                : "bg-white text-black hover:bg-gray-100",
+            )}
+          >
+            {g.year}
+          </Link>
+        ))}
+      </div>
+      
+      <div className="flex flex-col items-center space-y-4">
+        <div className="text-lg">
+          <p>
+            <span className="font-semibold">{game.year}:</span>{" "}
+            {game.title}
+          </p>
+        </div>
+        
+        {/* Game Image Section */}
+        <div className="flex justify-center">
+          {game.imageUrl ? (
+            <img
+              src={game.imageUrl}
+              alt={`${game.title} box art`}
+              className="w-64 h-64 object-cover rounded-lg shadow-lg"
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          ) : (
+            <div className="w-64 h-64 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
+              <p className="text-gray-500 text-center px-4">
+                No image available for<br />{game.title}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/game-of-the-year/GameDisplay.tsx
+++ b/app/game-of-the-year/GameDisplay.tsx
@@ -1,19 +1,25 @@
 "use client";
 
 import { useRouter, useParams } from "next/navigation";
-import Link from "next/link";
 import { useState, useTransition } from "react";
 import { classNames } from "../../lib/util";
+
+interface HonorableMention {
+  title: string;
+  description: string;
+}
 
 interface Game {
   year: number;
   title: string;
+  description: string;
+  honorableMentions?: HonorableMention[];
   imageUrl?: string | null;
 }
 
 interface GameDisplayProps {
   game: Game;
-  allGames: { year: number; title: string }[];
+  allGames: { year: number; title: string; description: string; honorableMentions?: HonorableMention[] }[];
 }
 
 export default function GameDisplay({ game, allGames }: GameDisplayProps) {
@@ -63,13 +69,19 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
       </div>
       
       <div className="flex flex-col items-center space-y-4">
-        <div className="text-lg">
+        <div className="text-center">
           <p className={classNames(
-            "transition-opacity duration-200",
+            "text-lg transition-opacity duration-200",
             isPending ? "opacity-50" : "opacity-100"
           )}>
             <span className="font-semibold">{game.year}:</span>{" "}
             {game.title}
+          </p>
+          <p className={classNames(
+            "text-gray-600 mt-2 max-w-md mx-auto transition-opacity duration-200",
+            isPending ? "opacity-50" : "opacity-100"
+          )}>
+            {game.description}
           </p>
         </div>
         
@@ -98,6 +110,33 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
             </div>
           )}
         </div>
+        
+        {/* Honorable Mentions Section */}
+        {game.honorableMentions && game.honorableMentions.length > 0 && (
+          <div className={classNames(
+            "mt-8 max-w-4xl mx-auto transition-opacity duration-200",
+            isPending ? "opacity-50" : "opacity-100"
+          )}>
+            <h3 className="text-xl font-semibold text-indigo-600 mb-4 text-center">
+              Honorable Mentions
+            </h3>
+            <div className="flex flex-wrap justify-center gap-4">
+              {game.honorableMentions.map((mention, index) => (
+                <div
+                  key={index}
+                  className="bg-gray-50 rounded-lg p-4 border border-gray-200 min-w-[280px] max-w-[320px] flex-shrink-0"
+                >
+                  <h4 className="font-medium text-gray-900 mb-1 text-center">
+                    {mention.title}
+                  </h4>
+                  <p className="text-sm text-gray-600 text-center">
+                    {mention.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/game-of-the-year/GameDisplay.tsx
+++ b/app/game-of-the-year/GameDisplay.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
+import { useState, useTransition } from "react";
 import { classNames } from "../../lib/util";
 
 interface Game {
@@ -16,29 +17,57 @@ interface GameDisplayProps {
 }
 
 export default function GameDisplay({ game, allGames }: GameDisplayProps) {
+  const router = useRouter();
+  const params = useParams();
+  const [isPending, startTransition] = useTransition();
+  const [pendingYear, setPendingYear] = useState<number | null>(null);
+  const currentYear = parseInt(params.year as string);
+
+  const handleYearClick = (year: number) => {
+    if (year === currentYear) return;
+    
+    setPendingYear(year);
+    startTransition(() => {
+      router.push(`/game-of-the-year/${year}`);
+    });
+  };
+
   return (
     <>
       <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 justify-center mb-6">
-        {allGames.map((g) => (
-          <Link
-            key={g.year}
-            href={`/game-of-the-year/${g.year}`}
-            prefetch={true}
-            className={classNames(
-              "px-3 py-2 rounded border inline-block text-center transition-colors duration-150",
-              game.year === g.year
-                ? "bg-indigo-600 text-white"
-                : "bg-white text-black hover:bg-gray-100",
-            )}
-          >
-            {g.year}
-          </Link>
-        ))}
+        {allGames.map((g) => {
+          const isSelected = currentYear === g.year;
+          const isPendingThis = pendingYear === g.year;
+          
+          return (
+            <button
+              key={g.year}
+              onClick={() => handleYearClick(g.year)}
+              disabled={isPending}
+              className={classNames(
+                "px-3 py-2 rounded border transition-all duration-200",
+                isSelected
+                  ? "bg-indigo-600 text-white"
+                  : isPendingThis
+                  ? "bg-indigo-400 text-white animate-pulse"
+                  : "bg-white text-black hover:bg-gray-100",
+                isPending && !isSelected && !isPendingThis
+                  ? "opacity-50 cursor-not-allowed"
+                  : "cursor-pointer"
+              )}
+            >
+              {g.year}
+            </button>
+          );
+        })}
       </div>
       
       <div className="flex flex-col items-center space-y-4">
         <div className="text-lg">
-          <p>
+          <p className={classNames(
+            "transition-opacity duration-200",
+            isPending ? "opacity-50" : "opacity-100"
+          )}>
             <span className="font-semibold">{game.year}:</span>{" "}
             {game.title}
           </p>
@@ -50,13 +79,19 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
             <img
               src={game.imageUrl}
               alt={`${game.title} box art`}
-              className="w-64 h-64 object-cover rounded-lg shadow-lg"
+              className={classNames(
+                "w-64 h-64 object-cover rounded-lg shadow-lg transition-all duration-300",
+                isPending ? "opacity-50 scale-95" : "opacity-100 scale-100"
+              )}
               onError={(e) => {
                 e.currentTarget.style.display = 'none';
               }}
             />
           ) : (
-            <div className="w-64 h-64 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
+            <div className={classNames(
+              "w-64 h-64 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300 transition-all duration-300",
+              isPending ? "opacity-50 scale-95" : "opacity-100 scale-100"
+            )}>
               <p className="text-gray-500 text-center px-4">
                 No image available for<br />{game.title}
               </p>

--- a/app/game-of-the-year/[year]/loading.tsx
+++ b/app/game-of-the-year/[year]/loading.tsx
@@ -1,0 +1,27 @@
+export default function Loading() {
+  return (
+    <div className="p-5 text-center">
+      <h1 className="text-3xl mb-4 font-bold text-indigo-600">
+        Game of the Year
+      </h1>
+      
+      {/* Simple loading state - only shown in edge cases with force-static */}
+      <div className="flex flex-col items-center space-y-4">
+        <div className="text-lg">
+          <div className="h-6 bg-gray-200 rounded w-48 animate-pulse"></div>
+        </div>
+        
+        {/* Loading image placeholder */}
+        <div className="flex justify-center">
+          <div className="w-64 h-64 bg-gray-200 rounded-lg flex items-center justify-center animate-pulse">
+            <div className="text-gray-400">
+              <svg className="w-12 h-12" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/game-of-the-year/[year]/page.tsx
+++ b/app/game-of-the-year/[year]/page.tsx
@@ -7,9 +7,16 @@ import { notFound } from "next/navigation";
 export const dynamic = 'force-static'; // Force static generation
 export const revalidate = false; // Never revalidate (cache indefinitely)
 
+interface HonorableMention {
+  title: string;
+  description: string;
+}
+
 interface Entry {
   year: number;
   title: string;
+  description: string;
+  honorableMentions?: HonorableMention[];
 }
 
 interface GameData {

--- a/app/game-of-the-year/[year]/page.tsx
+++ b/app/game-of-the-year/[year]/page.tsx
@@ -1,0 +1,88 @@
+import data from "../goty.json";
+import GameDisplay from "../GameDisplay";
+import { notFound } from "next/navigation";
+
+// Route segment config - cache this route statically
+// See: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
+export const dynamic = 'force-static'; // Force static generation
+export const revalidate = false; // Never revalidate (cache indefinitely)
+
+interface Entry {
+  year: number;
+  title: string;
+}
+
+interface GameData {
+  background_image?: string;
+  name?: string;
+}
+
+async function fetchGameImage(gameTitle: string, apiKey: string): Promise<string | null> {
+  try {
+    const response = await fetch(
+      `https://api.rawg.io/api/games?key=${apiKey}&search=${encodeURIComponent(gameTitle)}&page_size=1`,
+      {
+        // Cache indefinitely - won't revalidate until next deployment
+        // See: https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache
+        cache: 'force-cache'
+      }
+    );
+    const data = await response.json();
+    
+    if (data.results && data.results.length > 0) {
+      const game: GameData = data.results[0];
+      return game.background_image || null;
+    }
+    return null;
+  } catch (error) {
+    console.error(`Failed to fetch image for ${gameTitle}:`, error);
+    return null;
+  }
+}
+
+interface PageProps {
+  params: Promise<{
+    year: string;
+  }>;
+}
+
+export default async function GameOfTheYearPage({ params }: PageProps) {
+  const gotyData: Entry[] = data as Entry[];
+  const { year: yearString } = await params;
+  const year = parseInt(yearString);
+  
+  // Find the game for this specific year
+  const game = gotyData.find((g) => g.year === year);
+  
+  if (!game) {
+    notFound();
+  }
+  
+  const apiKey = process.env.RAWG_API_KEY!;
+  
+  // Fetch only the image for this specific game
+  const imageUrl = await fetchGameImage(game.title, apiKey);
+  
+  const gameWithImage = {
+    ...game,
+    imageUrl,
+  };
+
+  return (
+    <div className="p-5 text-center">
+      <h1 className="text-3xl mb-4 font-bold text-indigo-600">
+        Game of the Year
+      </h1>
+      <GameDisplay game={gameWithImage} allGames={gotyData} />
+    </div>
+  );
+}
+
+// Generate static params for all available years
+export async function generateStaticParams() {
+  const gotyData: Entry[] = data as Entry[];
+  
+  return gotyData.map((game) => ({
+    year: game.year.toString(),
+  }));
+}

--- a/app/game-of-the-year/goty.json
+++ b/app/game-of-the-year/goty.json
@@ -1,7 +1,33 @@
 [
-  { "year": 2024, "title": "Baldur's Gate 3" },
-  { "year": 2023, "title": "The Legend of Zelda: Tears of the Kingdom" },
-  { "year": 2022, "title": "Elden Ring" },
-  { "year": 2021, "title": "Metroid Dread" },
-  { "year": 2020, "title": "Hades" }
+  { 
+    "year": 2024, 
+    "title": "Astro Bot",
+    "description": "make platformers great again"
+  },
+  { 
+    "year": 2023, 
+    "title": "The Legend of Zelda: Tears of the Kingdom",
+    "description": "🐐",
+    "honorableMentions": [
+      {
+        "title": "Bayonetta Origins: Cereza and the Lost Demon",
+        "description": "My thumbs are sore"
+      }
+    ]
+  },
+  { 
+    "year": 2022, 
+    "title": "Elden Ring",
+    "description": "FOUL TARNISHED"
+  },
+  { 
+    "year": 2021, 
+    "title": "Metroid Dread",
+    "description": "2d 🐐"
+  },
+  { 
+    "year": 2020, 
+    "title": "Demon's Souls",
+    "description": "Still best looking game on PS5"
+  }
 ]

--- a/app/game-of-the-year/goty.json
+++ b/app/game-of-the-year/goty.json
@@ -1,0 +1,7 @@
+[
+  { "year": 2024, "title": "Baldur's Gate 3" },
+  { "year": 2023, "title": "The Legend of Zelda: Tears of the Kingdom" },
+  { "year": 2022, "title": "Elden Ring" },
+  { "year": 2021, "title": "Metroid Dread" },
+  { "year": 2020, "title": "Hades" }
+]

--- a/app/game-of-the-year/page.tsx
+++ b/app/game-of-the-year/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import data from "./goty.json";
+import { classNames } from "../../lib/util";
+
+interface Entry {
+  year: number;
+  title: string;
+}
+
+export default function GameOfTheYear() {
+  const gotyData: Entry[] = data as Entry[];
+  const [selectedYear, setSelectedYear] = useState<number>(gotyData[0].year);
+
+  const current = gotyData.find((g) => g.year === selectedYear);
+
+  return (
+    <div className="p-5 text-center">
+      <h1 className="text-3xl mb-4 font-bold text-indigo-600">
+        Game of the Year
+      </h1>
+      <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 justify-center mb-6">
+        {gotyData.map((g) => (
+          <button
+            key={g.year}
+            onClick={() => setSelectedYear(g.year)}
+            className={classNames(
+              "px-3 py-2 rounded border",
+              selectedYear === g.year
+                ? "bg-indigo-600 text-white"
+                : "bg-white text-black hover:bg-gray-100",
+            )}
+          >
+            {g.year}
+          </button>
+        ))}
+      </div>
+      {current && (
+        <div className="text-lg">
+          <p>
+            <span className="font-semibold">{current.year}:</span>{" "}
+            {current.title}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game-of-the-year/page.tsx
+++ b/app/game-of-the-year/page.tsx
@@ -1,8 +1,5 @@
-"use client";
-
-import { useState } from "react";
+import { redirect } from "next/navigation";
 import data from "./goty.json";
-import { classNames } from "../../lib/util";
 
 interface Entry {
   year: number;
@@ -11,39 +8,8 @@ interface Entry {
 
 export default function GameOfTheYear() {
   const gotyData: Entry[] = data as Entry[];
-  const [selectedYear, setSelectedYear] = useState<number>(gotyData[0].year);
-
-  const current = gotyData.find((g) => g.year === selectedYear);
-
-  return (
-    <div className="p-5 text-center">
-      <h1 className="text-3xl mb-4 font-bold text-indigo-600">
-        Game of the Year
-      </h1>
-      <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 justify-center mb-6">
-        {gotyData.map((g) => (
-          <button
-            key={g.year}
-            onClick={() => setSelectedYear(g.year)}
-            className={classNames(
-              "px-3 py-2 rounded border",
-              selectedYear === g.year
-                ? "bg-indigo-600 text-white"
-                : "bg-white text-black hover:bg-gray-100",
-            )}
-          >
-            {g.year}
-          </button>
-        ))}
-      </div>
-      {current && (
-        <div className="text-lg">
-          <p>
-            <span className="font-semibold">{current.year}:</span>{" "}
-            {current.title}
-          </p>
-        </div>
-      )}
-    </div>
-  );
+  
+  // Redirect to the first (most recent) year
+  const firstYear = gotyData[0].year;
+  redirect(`/game-of-the-year/${firstYear}`);
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,6 +12,7 @@ const defaultNavigation = [
   { name: "Blog", href: "/blog", current: false },
   { name: "Fusion Calculator", href: "/fusion-calculator", current: false },
   { name: "Smoothie Calculator", href: "/smoothie-calculator", current: false },
+  { name: "Game of the Year", href: "/game-of-the-year", current: false },
 ];
 
 export default function Navbar() {


### PR DESCRIPTION
## Summary
- introduce configurable data for Game of the Year picks
- create interactive Game of the Year page
- expose link in the main navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c514703a4832e9e31e5869e20d64f