### PR TITLE
Add info tooltip to GOTY page

### DIFF
--- a/app/game-of-the-year/GameDisplay.tsx
+++ b/app/game-of-the-year/GameDisplay.tsx
@@ -91,6 +91,7 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
             <img
               src={game.imageUrl}
               alt={`${game.title} box art`}
+              loading="lazy"
               className={classNames(
                 "w-64 h-64 object-cover rounded-lg shadow-lg transition-all duration-300",
                 isPending ? "opacity-50 scale-95" : "opacity-100 scale-100"

--- a/app/game-of-the-year/[year]/page.tsx
+++ b/app/game-of-the-year/[year]/page.tsx
@@ -1,5 +1,6 @@
 import data from "../goty.json";
 import GameDisplay from "../GameDisplay";
+import InfoTooltip from "../../../components/InfoTooltip";
 import { notFound } from "next/navigation";
 
 // Route segment config - cache this route statically
@@ -65,10 +66,15 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
     notFound();
   }
   
-  const apiKey = process.env.RAWG_API_KEY!;
-  
-  // Fetch only the image for this specific game
-  const imageUrl = await fetchGameImage(game.title, apiKey);
+  const apiKey = process.env.RAWG_API_KEY;
+  let imageUrl: string | null = null;
+
+  if (apiKey) {
+    // Fetch only the image for this specific game
+    imageUrl = await fetchGameImage(game.title, apiKey);
+  } else {
+    console.warn("RAWG_API_KEY is not set; skipping image fetch.");
+  }
   
   const gameWithImage = {
     ...game,
@@ -77,8 +83,17 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
 
   return (
     <div className="p-5 text-center">
-      <h1 className="text-3xl mb-4 font-bold text-indigo-600">
+      <h1 className="text-3xl mb-4 font-bold text-indigo-600 flex items-center justify-center gap-2">
         Game of the Year
+        <InfoTooltip>
+          <p className="text-left">
+            This page bookmarks my recent Game of the Year picks and
+            demonstrates lazy loading of images from the RAWG API. Images are
+            fetched server-side with an aggressive cache so the API key remains
+            secret and requests stay within rate limits. A placeholder
+            silhouette is shown while each image loads.
+          </p>
+        </InfoTooltip>
       </h1>
       <GameDisplay game={gameWithImage} allGames={gotyData} />
     </div>

--- a/app/game-of-the-year/[year]/page.tsx
+++ b/app/game-of-the-year/[year]/page.tsx
@@ -87,11 +87,11 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
         Game of the Year
         <InfoTooltip>
           <p className="text-left">
-            This page bookmarks my recent Game of the Year picks and
-            demonstrates lazy loading of images from the RAWG API. Images are
+            This page bookmarks my Game of the Year picks and was really built to 
+            try implementing lazy loading of images from a remote API with prefetching. Images are
             fetched server-side with an aggressive cache so the API key remains
             secret and requests stay within rate limits. A placeholder
-            silhouette is shown while each image loads.
+            container is displayed while each image loads.
           </p>
         </InfoTooltip>
       </h1>

--- a/components/InfoTooltip.tsx
+++ b/components/InfoTooltip.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+
+interface InfoTooltipProps {
+  children: React.ReactNode;
+}
+
+export default function InfoTooltip({ children }: InfoTooltipProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Information"
+        className="w-5 h-5 flex items-center justify-center rounded-full border border-gray-400 bg-white text-gray-600"
+      >
+        <InformationCircleIcon className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute z-10 left-1/2 -translate-x-1/2 mt-2 w-72 rounded bg-gray-800 p-3 text-sm text-white shadow-lg">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/InfoTooltip.tsx
+++ b/components/InfoTooltip.tsx
@@ -20,9 +20,9 @@ export default function InfoTooltip({ children }: InfoTooltipProps) {
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-label="Information"
-        className="w-5 h-5 flex items-center justify-center rounded-full border border-gray-400 bg-white text-gray-600"
+        className="w-6 h-6 flex items-center justify-center rounded-full border border-gray-400 bg-white text-gray-600"
       >
-        <InformationCircleIcon className="w-4 h-4" />
+        <InformationCircleIcon className="w-6 h-6" />
       </button>
       {open && (
         <div className="absolute z-10 left-1/2 -translate-x-1/2 mt-2 w-72 rounded bg-gray-800 p-3 text-sm text-white shadow-lg">


### PR DESCRIPTION
## Summary
- add a reusable `InfoTooltip` component
- explain purpose of the Game of the Year page via tooltip
- handle missing RAWG API key gracefully
- lazily load GOTY images

## Testing
- `npm run prettier:fix`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687da27c6100832ea753286dbe14f93a