### PR TITLE
Revamp navigation with categories and sidebar

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ This is a personal website that serves as a portfolio and houses various miscell
   - `blog/`: MDX-powered blog system with syntax highlighting and post management
   - **Project directories**: Each tool/calculator/game lives in its own directory (e.g., `fusion-calculator/`, `smoothie-calculator/`). New projects should follow this pattern with kebab-case naming.
 - `/components/`: Reusable React components (PascalCase naming)
+- `/hooks/`: Custom React hooks for shared stateful logic (camelCase naming)
 - `/posts/`: MDX blog posts with frontmatter
 - `/lib/`: Shared utility functions
 - `/styles/`: Global CSS and styling
@@ -57,6 +58,7 @@ When adding new projects, follow the established pattern of creating a dedicated
 - Write meaningful component and function names
 - Use proper TypeScript interfaces or types (prefer types) for props and data structures
 - Prefer small and composable functions that can be reused
+- Prefer to create reusable hooks and place them in the hooks folder when possible
 
 ## File and Directory Naming
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,12 +20,14 @@ This is a personal website that serves as a portfolio and houses various miscell
 ## Project Types and Patterns
 
 This site hosts various types of interactive projects:
+
 - **Calculators**: Tools that help users compute or determine something (fusion calculator, smoothie calculator)
 - **Games**: Interactive entertainment projects
 - **Utilities**: Simple tools for generating or manipulating data (random string generator)
 - **Informational**: Pages that display curated content (game of the year)
 
 When adding new projects, follow the established pattern of creating a dedicated directory under `/app/` with:
+
 - `page.tsx`: Main component (prefer server components; push interactivity to leaf components)
 - `util.ts`: Project-specific logic and calculations (colocate with usage when possible)
 - Data files in JSON format (if needed)

--- a/app/about-me/page.tsx
+++ b/app/about-me/page.tsx
@@ -1,6 +1,6 @@
 function Page() {
   return (
-    <div className="flex flex-col items-center justify-center h-screen text-center bg-white p-5">
+    <div className="flex flex-col items-center justify-center min-h-full text-center bg-white p-5">
       <h1 className="text-6xl text-black mb-5">About Me</h1>
       <p className="text-xl text-black mb-2">
         Hello, I&apos;m Sam. I am a software engineer from Puerto Rico. I enjoy

--- a/app/game-of-the-year/GameDisplay.tsx
+++ b/app/game-of-the-year/GameDisplay.tsx
@@ -19,7 +19,12 @@ interface Game {
 
 interface GameDisplayProps {
   game: Game;
-  allGames: { year: number; title: string; description: string; honorableMentions?: HonorableMention[] }[];
+  allGames: {
+    year: number;
+    title: string;
+    description: string;
+    honorableMentions?: HonorableMention[];
+  }[];
 }
 
 export default function GameDisplay({ game, allGames }: GameDisplayProps) {
@@ -31,7 +36,7 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
 
   const handleYearClick = (year: number) => {
     if (year === currentYear) return;
-    
+
     setPendingYear(year);
     startTransition(() => {
       router.push(`/game-of-the-year/${year}`);
@@ -44,7 +49,7 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
         {allGames.map((g) => {
           const isSelected = currentYear === g.year;
           const isPendingThis = pendingYear === g.year;
-          
+
           return (
             <button
               key={g.year}
@@ -55,11 +60,11 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
                 isSelected
                   ? "bg-indigo-600 text-white"
                   : isPendingThis
-                  ? "bg-indigo-400 text-white animate-pulse"
-                  : "bg-white text-black hover:bg-gray-100",
+                    ? "bg-indigo-400 text-white animate-pulse"
+                    : "bg-white text-black hover:bg-gray-100",
                 isPending && !isSelected && !isPendingThis
                   ? "opacity-50 cursor-not-allowed"
-                  : "cursor-pointer"
+                  : "cursor-pointer",
               )}
             >
               {g.year}
@@ -67,24 +72,27 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
           );
         })}
       </div>
-      
+
       <div className="flex flex-col items-center space-y-4">
         <div className="text-center">
-          <p className={classNames(
-            "text-lg transition-opacity duration-200",
-            isPending ? "opacity-50" : "opacity-100"
-          )}>
-            <span className="font-semibold">{game.year}:</span>{" "}
-            {game.title}
+          <p
+            className={classNames(
+              "text-lg transition-opacity duration-200",
+              isPending ? "opacity-50" : "opacity-100",
+            )}
+          >
+            <span className="font-semibold">{game.year}:</span> {game.title}
           </p>
-          <p className={classNames(
-            "text-gray-600 mt-2 max-w-md mx-auto transition-opacity duration-200",
-            isPending ? "opacity-50" : "opacity-100"
-          )}>
+          <p
+            className={classNames(
+              "text-gray-600 mt-2 max-w-md mx-auto transition-opacity duration-200",
+              isPending ? "opacity-50" : "opacity-100",
+            )}
+          >
             {game.description}
           </p>
         </div>
-        
+
         {/* Game Image Section */}
         <div className="flex justify-center">
           {game.imageUrl ? (
@@ -94,30 +102,36 @@ export default function GameDisplay({ game, allGames }: GameDisplayProps) {
               loading="lazy"
               className={classNames(
                 "w-64 h-64 object-cover rounded-lg shadow-lg transition-all duration-300",
-                isPending ? "opacity-50 scale-95" : "opacity-100 scale-100"
+                isPending ? "opacity-50 scale-95" : "opacity-100 scale-100",
               )}
               onError={(e) => {
-                e.currentTarget.style.display = 'none';
+                e.currentTarget.style.display = "none";
               }}
             />
           ) : (
-            <div className={classNames(
-              "w-64 h-64 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300 transition-all duration-300",
-              isPending ? "opacity-50 scale-95" : "opacity-100 scale-100"
-            )}>
+            <div
+              className={classNames(
+                "w-64 h-64 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300 transition-all duration-300",
+                isPending ? "opacity-50 scale-95" : "opacity-100 scale-100",
+              )}
+            >
               <p className="text-gray-500 text-center px-4">
-                No image available for<br />{game.title}
+                No image available for
+                <br />
+                {game.title}
               </p>
             </div>
           )}
         </div>
-        
+
         {/* Honorable Mentions Section */}
         {game.honorableMentions && game.honorableMentions.length > 0 && (
-          <div className={classNames(
-            "mt-8 max-w-4xl mx-auto transition-opacity duration-200",
-            isPending ? "opacity-50" : "opacity-100"
-          )}>
+          <div
+            className={classNames(
+              "mt-8 max-w-4xl mx-auto transition-opacity duration-200",
+              isPending ? "opacity-50" : "opacity-100",
+            )}
+          >
             <h3 className="text-xl font-semibold text-indigo-600 mb-4 text-center">
               Honorable Mentions
             </h3>

--- a/app/game-of-the-year/[year]/loading.tsx
+++ b/app/game-of-the-year/[year]/loading.tsx
@@ -4,19 +4,27 @@ export default function Loading() {
       <h1 className="text-3xl mb-4 font-bold text-indigo-600">
         Game of the Year
       </h1>
-      
+
       {/* Simple loading state - only shown in edge cases with force-static */}
       <div className="flex flex-col items-center space-y-4">
         <div className="text-lg">
           <div className="h-6 bg-gray-200 rounded w-48 animate-pulse"></div>
         </div>
-        
+
         {/* Loading image placeholder */}
         <div className="flex justify-center">
           <div className="w-64 h-64 bg-gray-200 rounded-lg flex items-center justify-center animate-pulse">
             <div className="text-gray-400">
-              <svg className="w-12 h-12" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+              <svg
+                className="w-12 h-12"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"
+                  clipRule="evenodd"
+                />
               </svg>
             </div>
           </div>

--- a/app/game-of-the-year/[year]/page.tsx
+++ b/app/game-of-the-year/[year]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation";
 
 // Route segment config - cache this route statically
 // See: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
-export const dynamic = 'force-static'; // Force static generation
+export const dynamic = "force-static"; // Force static generation
 export const revalidate = false; // Never revalidate (cache indefinitely)
 
 interface HonorableMention {
@@ -25,18 +25,21 @@ interface GameData {
   name?: string;
 }
 
-async function fetchGameImage(gameTitle: string, apiKey: string): Promise<string | null> {
+async function fetchGameImage(
+  gameTitle: string,
+  apiKey: string,
+): Promise<string | null> {
   try {
     const response = await fetch(
       `https://api.rawg.io/api/games?key=${apiKey}&search=${encodeURIComponent(gameTitle)}&page_size=1`,
       {
         // Cache indefinitely - won't revalidate until next deployment
         // See: https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache
-        cache: 'force-cache'
-      }
+        cache: "force-cache",
+      },
     );
     const data = await response.json();
-    
+
     if (data.results && data.results.length > 0) {
       const game: GameData = data.results[0];
       return game.background_image || null;
@@ -58,14 +61,14 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
   const gotyData: Entry[] = data as Entry[];
   const { year: yearString } = await params;
   const year = parseInt(yearString);
-  
+
   // Find the game for this specific year
   const game = gotyData.find((g) => g.year === year);
-  
+
   if (!game) {
     notFound();
   }
-  
+
   const apiKey = process.env.RAWG_API_KEY;
   let imageUrl: string | null = null;
 
@@ -75,7 +78,7 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
   } else {
     console.warn("RAWG_API_KEY is not set; skipping image fetch.");
   }
-  
+
   const gameWithImage = {
     ...game,
     imageUrl,
@@ -87,11 +90,11 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
         Game of the Year
         <InfoTooltip>
           <p className="text-left">
-            This page bookmarks my Game of the Year picks and was really built to 
-            try implementing lazy loading of images from a remote API with prefetching. Images are
-            fetched server-side with an aggressive cache so the API key remains
-            secret and requests stay within rate limits. A placeholder
-            container is displayed while each image loads.
+            This page bookmarks my Game of the Year picks and was really built
+            to try implementing lazy loading of images from a remote API with
+            prefetching. Images are fetched server-side with an aggressive cache
+            so the API key remains secret and requests stay within rate limits.
+            A placeholder container is displayed while each image loads.
           </p>
         </InfoTooltip>
       </h1>
@@ -103,7 +106,7 @@ export default async function GameOfTheYearPage({ params }: PageProps) {
 // Generate static params for all available years
 export async function generateStaticParams() {
   const gotyData: Entry[] = data as Entry[];
-  
+
   return gotyData.map((game) => ({
     year: game.year.toString(),
   }));

--- a/app/game-of-the-year/goty.json
+++ b/app/game-of-the-year/goty.json
@@ -1,11 +1,11 @@
 [
-  { 
-    "year": 2024, 
+  {
+    "year": 2024,
     "title": "Astro Bot",
     "description": "make platformers great again"
   },
-  { 
-    "year": 2023, 
+  {
+    "year": 2023,
     "title": "The Legend of Zelda: Tears of the Kingdom",
     "description": "🐐",
     "honorableMentions": [
@@ -15,18 +15,18 @@
       }
     ]
   },
-  { 
-    "year": 2022, 
+  {
+    "year": 2022,
     "title": "Elden Ring",
     "description": "FOUL TARNISHED"
   },
-  { 
-    "year": 2021, 
+  {
+    "year": 2021,
     "title": "Metroid Dread",
     "description": "2d 🐐"
   },
-  { 
-    "year": 2020, 
+  {
+    "year": 2020,
     "title": "Demon's Souls",
     "description": "Still best looking game on PS5"
   }

--- a/app/game-of-the-year/page.tsx
+++ b/app/game-of-the-year/page.tsx
@@ -8,7 +8,7 @@ interface Entry {
 
 export default function GameOfTheYear() {
   const gotyData: Entry[] = data as Entry[];
-  
+
   // Redirect to the first (most recent) year
   const firstYear = gotyData[0].year;
   redirect(`/game-of-the-year/${firstYear}`);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,9 @@ export default function RootLayout({
       <body className={inter.className}>
         <div className="flex min-h-screen">
           <Sidebar />
-          <main className="flex-1 p-4 h-screen overflow-y-auto box-border">{children}</main>
+          <main className="flex-1 p-4 h-screen overflow-y-auto box-border">
+            {children}
+          </main>
         </div>
       </body>
       <Analytics />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "../styles/globals.css";
 import { Analytics } from "@vercel/analytics/react";
 import { Inter } from "next/font/google";
-import Navbar from "../components/Navbar";
 import Sidebar from "../components/Sidebar";
 
 export const metadata = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,17 +2,18 @@ import "../styles/globals.css";
 import { Analytics } from "@vercel/analytics/react";
 import { Inter } from "next/font/google";
 import Navbar from "../components/Navbar";
+import Sidebar from "../components/Sidebar";
 
 export const metadata = {
   title: "Sam's Fun House",
   description: "I just put whatever here",
   icons: {
     icon: [
-      { url: '/favicon.svg', type: 'image/svg+xml' },
-      { url: '/favicon-16x16.svg', type: 'image/svg+xml', sizes: '16x16' },
-      { url: '/favicon-32x32.svg', type: 'image/svg+xml', sizes: '32x32' },
+      { url: "/favicon.svg", type: "image/svg+xml" },
+      { url: "/favicon-16x16.svg", type: "image/svg+xml", sizes: "16x16" },
+      { url: "/favicon-32x32.svg", type: "image/svg+xml", sizes: "32x32" },
     ],
-    shortcut: '/favicon.svg',
+    shortcut: "/favicon.svg",
   },
 };
 
@@ -27,7 +28,10 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <Navbar />
-        {children}
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <main className="flex-1 p-4">{children}</main>
+        </div>
       </body>
       <Analytics />
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,10 +27,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Navbar />
         <div className="flex min-h-screen">
           <Sidebar />
-          <main className="flex-1 p-4">{children}</main>
+          <main className="flex-1 p-4 h-screen overflow-y-auto box-border">{children}</main>
         </div>
       </body>
       <Analytics />

--- a/app/page.css
+++ b/app/page.css
@@ -16,7 +16,7 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  color: white;
+  color: #333;
   background-size: 200% 200%;
   background-image: linear-gradient(
     45deg,

--- a/app/page.css
+++ b/app/page.css
@@ -11,8 +11,11 @@
 }
 
 .home-container {
-  height: 100vh;
+  position: relative;
+  height: 100%;
+  min-height: calc(100vh - 2rem);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,33 +1,16 @@
 import Image from "next/image";
-import Link from "next/link";
 import "./page.css";
-import { categories } from "../lib/navigation";
 
 function Home() {
   return (
-    <div className="home-container p-4 space-y-8">
-      {categories.map((category) => (
-        <section key={category.title}>
-          <h2 className="mb-4 text-xl font-semibold">{category.title}</h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
-            {category.items.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className="block rounded-lg bg-white/70 p-4 text-center font-medium text-gray-800 shadow hover:bg-white"
-              >
-                {item.name}
-              </Link>
-            ))}
-          </div>
-        </section>
-      ))}
+    <div className="home-container">
+      <h1>Hello, world</h1>
       <Image
         src="/kiki-fly.svg"
         alt="A flying Kiki"
-        className="fixed bottom-2 right-2 w-16"
-        width={64}
-        height={64}
+        className="absolute bottom-4 right-4 w-16"
+        width={500}
+        height={500}
       />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,33 @@
 import Image from "next/image";
+import Link from "next/link";
 import "./page.css";
+import { categories } from "../lib/navigation";
 
 function Home() {
   return (
-    <div className="home-container">
-      <h1>Hello, world.</h1>
+    <div className="home-container p-4 space-y-8">
+      {categories.map((category) => (
+        <section key={category.title}>
+          <h2 className="mb-4 text-xl font-semibold">{category.title}</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {category.items.map((item) => (
+              <Link
+                key={item.name}
+                href={item.href}
+                className="block rounded-lg bg-white/70 p-4 text-center font-medium text-gray-800 shadow hover:bg-white"
+              >
+                {item.name}
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
       <Image
         src="/kiki-fly.svg"
         alt="A flying Kiki"
         className="fixed bottom-2 right-2 w-16"
-        width={500}
-        height={500}
+        width={64}
+        height={64}
       />
     </div>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,28 +1,19 @@
 "use client";
 
-import { Disclosure } from "@headlessui/react";
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Disclosure, Menu, Transition } from "@headlessui/react";
+import {
+  Bars3Icon,
+  XMarkIcon,
+  ChevronDownIcon,
+} from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { classNames } from "../lib/util";
-
-const defaultNavigation = [
-  { name: "About Me", href: "/about-me", current: false },
-  { name: "Blog", href: "/blog", current: false },
-  { name: "Fusion Calculator", href: "/fusion-calculator", current: false },
-  { name: "Smoothie Calculator", href: "/smoothie-calculator", current: false },
-  { name: "Game of the Year", href: "/game-of-the-year", current: false },
-  { name: "Random String", href: "/random-string", current: false },
-];
+import { categories } from "../lib/navigation";
 
 export default function Navbar() {
   const pathName = usePathname();
-
-  const navigation = defaultNavigation.map((item) => {
-    const current = pathName === item.href;
-    return { ...item, current };
-  });
 
   return (
     <Disclosure as="nav" className="bg-gray-800">
@@ -60,24 +51,41 @@ export default function Navbar() {
                     />
                   </Link>
                 </div>
-                <div className="hidden sm:ml-6 sm:block">
-                  <div className="flex space-x-4">
-                    {navigation.map((item) => (
-                      <a
-                        key={item.name}
-                        href={item.href}
-                        className={classNames(
-                          item.current
-                            ? "bg-gray-900 text-white"
-                            : "text-gray-300 hover:bg-gray-700 hover:text-white",
-                          "px-3 py-2 rounded-md text-sm font-medium",
-                        )}
-                        aria-current={item.current ? "page" : undefined}
+                <div className="hidden sm:ml-6 sm:flex space-x-4">
+                  {categories.map((category) => (
+                    <Menu as="div" key={category.title} className="relative">
+                      <Menu.Button className="inline-flex items-center rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white">
+                        {category.title}
+                        <ChevronDownIcon className="ml-1 h-4 w-4" />
+                      </Menu.Button>
+                      <Transition
+                        enter="transition ease-out duration-100"
+                        enterFrom="transform opacity-0 scale-95"
+                        enterTo="transform opacity-100 scale-100"
+                        leave="transition ease-in duration-75"
+                        leaveFrom="transform opacity-100 scale-100"
+                        leaveTo="transform opacity-0 scale-95"
                       >
-                        {item.name}
-                      </a>
-                    ))}
-                  </div>
+                        <Menu.Items className="absolute z-10 mt-2 w-48 origin-top-left rounded-md bg-white py-1 shadow-lg focus:outline-none">
+                          {category.items.map((item) => (
+                            <Menu.Item key={item.name}>
+                              {({ active }) => (
+                                <Link
+                                  href={item.href}
+                                  className={classNames(
+                                    active ? "bg-gray-100" : "",
+                                    "block px-4 py-2 text-sm text-gray-700",
+                                  )}
+                                >
+                                  {item.name}
+                                </Link>
+                              )}
+                            </Menu.Item>
+                          ))}
+                        </Menu.Items>
+                      </Transition>
+                    </Menu>
+                  ))}
                 </div>
               </div>
             </div>
@@ -85,21 +93,27 @@ export default function Navbar() {
 
           <Disclosure.Panel className="sm:hidden">
             <div className="space-y-1 px-2 pt-2 pb-3">
-              {navigation.map((item) => (
-                <Disclosure.Button
-                  key={item.name}
-                  as="a"
-                  href={item.href}
-                  className={classNames(
-                    item.current
-                      ? "bg-gray-900 text-white"
-                      : "text-gray-300 hover:bg-gray-700 hover:text-white",
-                    "block px-3 py-2 rounded-md text-base font-medium",
-                  )}
-                  aria-current={item.current ? "page" : undefined}
-                >
-                  {item.name}
-                </Disclosure.Button>
+              {categories.map((category) => (
+                <div key={category.title} className="pt-2">
+                  <p className="px-3 py-2 text-sm font-medium text-gray-400">
+                    {category.title}
+                  </p>
+                  {category.items.map((item) => (
+                    <Disclosure.Button
+                      key={item.name}
+                      as="a"
+                      href={item.href}
+                      className={classNames(
+                        pathName === item.href
+                          ? "bg-gray-900 text-white"
+                          : "text-gray-300 hover:bg-gray-700 hover:text-white",
+                        "block px-3 py-2 rounded-md text-base font-medium",
+                      )}
+                    >
+                      {item.name}
+                    </Disclosure.Button>
+                  ))}
+                </div>
               ))}
             </div>
           </Disclosure.Panel>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,38 +2,124 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { categories } from "../lib/navigation";
 import { classNames } from "../lib/util";
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed);
+  };
 
   return (
-    <nav className="w-56 bg-gray-100 p-4 space-y-4 overflow-y-auto">
-      {categories.map((category) => (
-        <div key={category.title}>
-          <h3 className="mb-2 text-sm font-semibold text-gray-700">
-            {category.title}
-          </h3>
-          <ul className="space-y-1">
-            {category.items.map((item) => (
-              <li key={item.name}>
+    <nav 
+      className={classNames(
+        "bg-gray-100 p-4 space-y-4 overflow-y-auto h-screen box-border relative transition-all duration-300 flex-shrink-0",
+        isCollapsed ? "w-16" : "w-56"
+      )}
+    >
+      {/* Toggle Button */}
+      <button
+        onClick={toggleCollapse}
+        className={classNames(
+          "absolute top-4 p-1 rounded hover:bg-gray-200 z-10",
+          isCollapsed ? "left-1/2 transform -translate-x-1/2" : "right-2"
+        )}
+        aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+      >
+        {isCollapsed ? (
+          <ChevronRightIcon className="w-4 h-4 text-gray-600" />
+        ) : (
+          <ChevronLeftIcon className="w-4 h-4 text-gray-600" />
+        )}
+      </button>
+
+      {!isCollapsed && (
+        <>
+          <div className="pb-4 border-b border-gray-200 pr-8">
+            <Link
+              href="/"
+              className={classNames(
+                pathname === "/"
+                  ? "text-indigo-600 font-medium"
+                  : "text-gray-600 hover:text-indigo-600",
+                "block px-2 py-1 text-sm rounded",
+              )}
+            >
+              Home
+            </Link>
+          </div>
+          
+          {categories.map((category) => (
+            <div key={category.title}>
+              <h3 className="mb-2 text-sm font-semibold text-gray-700">
+                {category.title}
+              </h3>
+              <ul className="space-y-1">
+                {category.items.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      href={item.href}
+                      className={classNames(
+                        pathname === item.href
+                          ? "text-indigo-600 font-medium"
+                          : "text-gray-600 hover:text-indigo-600",
+                        "block px-2 py-1 text-sm rounded",
+                      )}
+                    >
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </>
+      )}
+
+      {/* Collapsed state - show only icons or initials */}
+      {isCollapsed && (
+        <div className="space-y-2 pt-12">
+          <Link
+            href="/"
+            className={classNames(
+              pathname === "/"
+                ? "text-indigo-600 font-medium"
+                : "text-gray-600 hover:text-indigo-600",
+              "block px-2 py-1 text-xs text-center rounded",
+            )}
+            title="Home"
+          >
+            H
+          </Link>
+          {categories.map((category) => (
+            <div key={category.title} className="space-y-1">
+              <div className="text-xs font-semibold text-gray-700 text-center px-1 py-1">
+                {category.title.charAt(0)}
+              </div>
+              {category.items.map((item) => (
                 <Link
+                  key={item.name}
                   href={item.href}
                   className={classNames(
                     pathname === item.href
                       ? "text-indigo-600 font-medium"
                       : "text-gray-600 hover:text-indigo-600",
-                    "block px-2 py-1 text-sm rounded",
+                    "block px-1 py-1 text-xs text-center rounded",
                   )}
+                  title={item.name}
                 >
-                  {item.name}
+                  {item.name.charAt(0)}
                 </Link>
-              </li>
-            ))}
-          </ul>
+              ))}
+            </div>
+          ))}
         </div>
-      ))}
+      )}
     </nav>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -16,10 +16,10 @@ export default function Sidebar() {
   };
 
   return (
-    <nav 
+    <nav
       className={classNames(
         "bg-gray-100 p-4 space-y-4 overflow-y-auto h-screen box-border relative transition-all duration-300 flex-shrink-0",
-        isCollapsed ? "w-16" : "w-56"
+        isCollapsed ? "w-16" : "w-56",
       )}
     >
       {/* Toggle Button */}
@@ -27,7 +27,7 @@ export default function Sidebar() {
         onClick={toggleCollapse}
         className={classNames(
           "absolute top-4 p-1 rounded hover:bg-gray-200 z-10",
-          isCollapsed ? "left-1/2 transform -translate-x-1/2" : "right-2"
+          isCollapsed ? "left-1/2 transform -translate-x-1/2" : "right-2",
         )}
         aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
@@ -53,7 +53,7 @@ export default function Sidebar() {
               Home
             </Link>
           </div>
-          
+
           {categories.map((category) => (
             <div key={category.title}>
               <h3 className="mb-2 text-sm font-semibold text-gray-700">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
-import { categories, getItemEmoji, getCategoryEmoji } from "../lib/navigation";
+import { categories, getItemEmoji } from "../lib/navigation";
 import { classNames } from "../lib/util";
 
 export default function Sidebar() {
@@ -83,33 +83,34 @@ export default function Sidebar() {
 
       {/* Collapsed state - show only emojis */}
       {isCollapsed && (
-        <div className="space-y-2 pt-12">
+        <div className="space-y-3 pt-12">
           <Link
             href="/"
             className={classNames(
               pathname === "/"
                 ? "text-indigo-600 font-medium"
                 : "text-gray-600 hover:text-indigo-600",
-              "block px-2 py-1 text-xs text-center rounded",
+              "block px-2 py-2 text-lg text-center rounded",
             )}
             title="Home"
           >
             🏠
           </Link>
-          {categories.map((category) => (
-            <div key={category.title} className="space-y-1">
-              <div className="text-xs font-semibold text-gray-700 text-center px-1 py-1" title={category.title}>
-                {getCategoryEmoji(category)}
-              </div>
+          <div className="border-t border-gray-300 mx-2"></div>
+          {categories.map((category, categoryIndex) => (
+            <div key={category.title} className="space-y-2">
+              {categoryIndex > 0 && (
+                <div className="border-t border-gray-300 mx-2"></div>
+              )}
               {category.items.map((item) => (
                 <Link
                   key={item.name}
                   href={item.href}
                   className={classNames(
                     pathname === item.href
-                      ? "text-indigo-600 font-medium"
-                      : "text-gray-600 hover:text-indigo-600",
-                    "block px-1 py-1 text-xs text-center rounded",
+                      ? "text-indigo-600 font-medium bg-indigo-50"
+                      : "text-gray-600 hover:text-indigo-600 hover:bg-gray-50",
+                    "block px-1 py-2 text-lg text-center rounded transition-colors",
                   )}
                   title={item.name}
                 >

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { categories } from "../lib/navigation";
+import { classNames } from "../lib/util";
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="w-56 bg-gray-100 p-4 space-y-4 overflow-y-auto">
+      {categories.map((category) => (
+        <div key={category.title}>
+          <h3 className="mb-2 text-sm font-semibold text-gray-700">
+            {category.title}
+          </h3>
+          <ul className="space-y-1">
+            {category.items.map((item) => (
+              <li key={item.name}>
+                <Link
+                  href={item.href}
+                  className={classNames(
+                    pathname === item.href
+                      ? "text-indigo-600 font-medium"
+                      : "text-gray-600 hover:text-indigo-600",
+                    "block px-2 py-1 text-sm rounded",
+                  )}
+                >
+                  {item.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,9 +9,12 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 
 export default function Sidebar() {
   const pathname = usePathname();
-  
+
   // Use the reusable localStorage hook
-  const [isCollapsed, setIsCollapsed] = useLocalStorage('sidebar-collapsed', false);
+  const [isCollapsed, setIsCollapsed] = useLocalStorage(
+    "sidebar-collapsed",
+    false,
+  );
 
   const toggleCollapse = () => {
     setIsCollapsed(!isCollapsed);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,14 +2,27 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { categories, getItemEmoji } from "../lib/navigation";
 import { classNames } from "../lib/util";
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    try {
+      const savedState = localStorage.getItem('sidebar-collapsed');
+      return savedState !== null ? JSON.parse(savedState) : false;
+    } catch {
+      return false;
+    }
+  });
+  
+  // Save collapsed state to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsed));
+  }, [isCollapsed]);
 
   const toggleCollapse = () => {
     setIsCollapsed(!isCollapsed);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,27 +2,16 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { categories, getItemEmoji } from "../lib/navigation";
 import { classNames } from "../lib/util";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 
 export default function Sidebar() {
   const pathname = usePathname();
   
-  const [isCollapsed, setIsCollapsed] = useState(() => {
-    try {
-      const savedState = localStorage.getItem('sidebar-collapsed');
-      return savedState !== null ? JSON.parse(savedState) : false;
-    } catch {
-      return false;
-    }
-  });
-  
-  // Save collapsed state to localStorage whenever it changes
-  useEffect(() => {
-    localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsed));
-  }, [isCollapsed]);
+  // Use the reusable localStorage hook
+  const [isCollapsed, setIsCollapsed] = useLocalStorage('sidebar-collapsed', false);
 
   const toggleCollapse = () => {
     setIsCollapsed(!isCollapsed);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
-import { categories } from "../lib/navigation";
+import { categories, getItemEmoji, getCategoryEmoji } from "../lib/navigation";
 import { classNames } from "../lib/util";
 
 export default function Sidebar() {
@@ -81,7 +81,7 @@ export default function Sidebar() {
         </>
       )}
 
-      {/* Collapsed state - show only icons or initials */}
+      {/* Collapsed state - show only emojis */}
       {isCollapsed && (
         <div className="space-y-2 pt-12">
           <Link
@@ -94,12 +94,12 @@ export default function Sidebar() {
             )}
             title="Home"
           >
-            H
+            🏠
           </Link>
           {categories.map((category) => (
             <div key={category.title} className="space-y-1">
-              <div className="text-xs font-semibold text-gray-700 text-center px-1 py-1">
-                {category.title.charAt(0)}
+              <div className="text-xs font-semibold text-gray-700 text-center px-1 py-1" title={category.title}>
+                {getCategoryEmoji(category)}
               </div>
               {category.items.map((item) => (
                 <Link
@@ -113,7 +113,7 @@ export default function Sidebar() {
                   )}
                   title={item.name}
                 >
-                  {item.name.charAt(0)}
+                  {getItemEmoji(item)}
                 </Link>
               ))}
             </div>

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 
 /**
  * Custom hook for managing localStorage with automatic synchronization
@@ -6,7 +6,10 @@ import { useState, useEffect } from 'react';
  * @param initialValue - The initial value to use if no stored value exists
  * @returns [value, setValue] - Current value and setter function
  */
-export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, (value: T) => void] {
   // Always start with the initial value to avoid hydration mismatches
   const [storedValue, setStoredValue] = useState<T>(initialValue);
 

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook for managing localStorage with automatic synchronization
+ * @param key - The localStorage key
+ * @param initialValue - The initial value to use if no stored value exists
+ * @returns [value, setValue] - Current value and setter function
+ */
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  // Always start with the initial value to avoid hydration mismatches
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+  // Load value from localStorage after component mounts
+  useEffect(() => {
+    try {
+      const item = localStorage.getItem(key);
+      if (item !== null) {
+        setStoredValue(JSON.parse(item));
+      }
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+    }
+  }, [key]);
+
+  // Save to localStorage whenever value changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(storedValue));
+    } catch (error) {
+      console.warn(`Error setting localStorage key "${key}":`, error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue];
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,31 +1,45 @@
 export type NavigationItem = {
   name: string;
   href: string;
+  emoji?: string;
 };
 
 export type NavigationCategory = {
   title: string;
+  emoji?: string;
   items: NavigationItem[];
 };
 
 export const categories: NavigationCategory[] = [
   {
     title: "Personal",
+    emoji: "👤",
     items: [
-      { name: "About Me", href: "/about-me" },
-      { name: "Blog", href: "/blog" },
+      { name: "About Me", href: "/about-me", emoji: "👋" },
+      { name: "Blog", href: "/blog", emoji: "📝" },
     ],
   },
   {
     title: "Gaming",
+    emoji: "🎮",
     items: [
-      { name: "Fusion Calculator", href: "/fusion-calculator" },
-      { name: "Game of the Year", href: "/game-of-the-year" },
-      { name: "Smoothie Calculator", href: "/smoothie-calculator" },
+      { name: "Fusion Calculator", href: "/fusion-calculator", emoji: "⚡" },
+      { name: "Game of the Year", href: "/game-of-the-year", emoji: "🏆" },
+      { name: "Smoothie Calculator", href: "/smoothie-calculator", emoji: "🥤" },
     ],
   },
   {
     title: "Tools",
-    items: [{ name: "Random String", href: "/random-string" }],
+    emoji: "🔧",
+    items: [{ name: "Random String", href: "/random-string", emoji: "🎲" }],
   },
 ];
+
+// Utility function to get emoji with fallback
+export const getItemEmoji = (item: NavigationItem): string => {
+  return item.emoji || item.name.charAt(0).toUpperCase();
+};
+
+export const getCategoryEmoji = (category: NavigationCategory): string => {
+  return category.emoji || category.title.charAt(0).toUpperCase();
+};

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -21,7 +21,7 @@ export const categories: NavigationCategory[] = [
     items: [
       { name: "Fusion Calculator", href: "/fusion-calculator" },
       { name: "Game of the Year", href: "/game-of-the-year" },
-      { name: "Smoothie Calculator", href: "/smoothie-calculator" }
+      { name: "Smoothie Calculator", href: "/smoothie-calculator" },
     ],
   },
   {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,34 @@
+export type NavigationItem = {
+  name: string;
+  href: string;
+};
+
+export type NavigationCategory = {
+  title: string;
+  items: NavigationItem[];
+};
+
+export const categories: NavigationCategory[] = [
+  {
+    title: "Gaming",
+    items: [
+      { name: "Fusion Calculator", href: "/fusion-calculator" },
+      { name: "Game of the Year", href: "/game-of-the-year" },
+    ],
+  },
+  {
+    title: "Programming Tools",
+    items: [{ name: "Random String", href: "/random-string" }],
+  },
+  {
+    title: "Utilities",
+    items: [{ name: "Smoothie Calculator", href: "/smoothie-calculator" }],
+  },
+  {
+    title: "Personal",
+    items: [
+      { name: "About Me", href: "/about-me" },
+      { name: "Blog", href: "/blog" },
+    ],
+  },
+];

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -22,7 +22,11 @@ export const categories: NavigationCategory[] = [
     items: [
       { name: "Fusion Calculator", href: "/fusion-calculator", emoji: "⚡" },
       { name: "Game of the Year", href: "/game-of-the-year", emoji: "🏆" },
-      { name: "Smoothie Calculator", href: "/smoothie-calculator", emoji: "🥤" },
+      {
+        name: "Smoothie Calculator",
+        href: "/smoothie-calculator",
+        emoji: "🥤",
+      },
     ],
   },
   {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -10,25 +10,22 @@ export type NavigationCategory = {
 
 export const categories: NavigationCategory[] = [
   {
-    title: "Gaming",
-    items: [
-      { name: "Fusion Calculator", href: "/fusion-calculator" },
-      { name: "Game of the Year", href: "/game-of-the-year" },
-    ],
-  },
-  {
-    title: "Programming Tools",
-    items: [{ name: "Random String", href: "/random-string" }],
-  },
-  {
-    title: "Utilities",
-    items: [{ name: "Smoothie Calculator", href: "/smoothie-calculator" }],
-  },
-  {
     title: "Personal",
     items: [
       { name: "About Me", href: "/about-me" },
       { name: "Blog", href: "/blog" },
     ],
+  },
+  {
+    title: "Gaming",
+    items: [
+      { name: "Fusion Calculator", href: "/fusion-calculator" },
+      { name: "Game of the Year", href: "/game-of-the-year" },
+      { name: "Smoothie Calculator", href: "/smoothie-calculator" }
+    ],
+  },
+  {
+    title: "Tools",
+    items: [{ name: "Random String", href: "/random-string" }],
   },
 ];

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -6,14 +6,12 @@ export type NavigationItem = {
 
 export type NavigationCategory = {
   title: string;
-  emoji?: string;
   items: NavigationItem[];
 };
 
 export const categories: NavigationCategory[] = [
   {
     title: "Personal",
-    emoji: "👤",
     items: [
       { name: "About Me", href: "/about-me", emoji: "👋" },
       { name: "Blog", href: "/blog", emoji: "📝" },
@@ -21,7 +19,6 @@ export const categories: NavigationCategory[] = [
   },
   {
     title: "Gaming",
-    emoji: "🎮",
     items: [
       { name: "Fusion Calculator", href: "/fusion-calculator", emoji: "⚡" },
       { name: "Game of the Year", href: "/game-of-the-year", emoji: "🏆" },
@@ -30,7 +27,6 @@ export const categories: NavigationCategory[] = [
   },
   {
     title: "Tools",
-    emoji: "🔧",
     items: [{ name: "Random String", href: "/random-string", emoji: "🎲" }],
   },
 ];
@@ -38,8 +34,4 @@ export const categories: NavigationCategory[] = [
 // Utility function to get emoji with fallback
 export const getItemEmoji = (item: NavigationItem): string => {
   return item.emoji || item.name.charAt(0).toUpperCase();
-};
-
-export const getCategoryEmoji = (category: NavigationCategory): string => {
-  return category.emoji || category.title.charAt(0).toUpperCase();
 };


### PR DESCRIPTION
## Summary
- implement shared navigation categories
- add a sidebar for consistent navigation
- show category grid on the home page
- revise navigation bar to use dropdowns

## Testing
- `npm run prettier -- --write`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68832f91c9d8832eb3293e797acbc5a6