### PR TITLE
Add UTF-8 string length tool

### DIFF
--- a/__tests__/utf8.spec.ts
+++ b/__tests__/utf8.spec.ts
@@ -1,0 +1,15 @@
+import { utf8ByteCount, formatByteSize } from "../lib/utf8";
+
+describe("utf8 utilities", () => {
+  test("counts bytes correctly", () => {
+    expect(utf8ByteCount("a")).toBe(1);
+    expect(utf8ByteCount("é")).toBe(2);
+    expect(utf8ByteCount("😀")).toBe(4);
+  });
+
+  test("formats bytes", () => {
+    expect(formatByteSize(10)).toBe("10 bytes");
+    expect(formatByteSize(2048)).toBe("2.00 KB");
+    expect(formatByteSize(1048576)).toBe("1.00 MB");
+  });
+});

--- a/app/random-string/page.tsx
+++ b/app/random-string/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect, useState, useCallback, useRef, Suspense } from "react";
+import { formatUtf8ByteSize } from "../../lib/utf8";
 
 const DEFAULT_CHARSET =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -123,19 +124,10 @@ function RandomStringGenerator() {
     }
   }, [result]);
 
-  const getUtf8ByteSize = useCallback((str: string) => {
-    const bytes = new Blob([str]).size;
-
-    if (bytes < 1024) {
-      return `${bytes} bytes`;
-    } else if (bytes < 1024 * 1024) {
-      const kb = bytes / 1024;
-      return `${kb.toFixed(kb >= 100 ? 0 : kb >= 10 ? 1 : 2)} KB`;
-    } else {
-      const mb = bytes / (1024 * 1024);
-      return `${mb.toFixed(mb >= 100 ? 0 : mb >= 10 ? 1 : 2)} MB`;
-    }
-  }, []);
+  const getUtf8ByteSize = useCallback(
+    (str: string) => formatUtf8ByteSize(str),
+    [],
+  );
 
   const generateWithPresetLength = useCallback(
     (presetLength: number) => {

--- a/app/random-string/page.tsx
+++ b/app/random-string/page.tsx
@@ -135,10 +135,7 @@ function RandomStringGenerator() {
     }
   }, [result]);
 
-  const getUtf8ByteSize = useCallback(
-    (str: string) => formatUtf8ByteSize(str),
-    [],
-  );
+  const getUtf8ByteSize = (str: string) => formatUtf8ByteSize(str);
 
   const generateWithPresetLength = useCallback(
     (presetLength: number) => {

--- a/app/string-length/page.tsx
+++ b/app/string-length/page.tsx
@@ -1,25 +1,49 @@
 "use client";
 
-import { useState } from "react";
-import { formatUtf8ByteSize, utf8ByteCount } from "../../lib/utf8";
+import { Suspense } from "react";
+import { formatUtf8ByteSize } from "../../lib/utf8";
+import { useQueryParam, stringParam } from "../../hooks/useQueryParams";
 
-export default function StringLengthPage() {
-  const [text, setText] = useState("");
+function StringLengthChecker() {
+  const [text, setText] = useQueryParam(stringParam("text", "héllo ✅"));
 
   return (
-    <div className="p-4 max-w-2xl mx-auto space-y-4">
-      <h1 className="text-2xl font-bold">UTF-8 Length Checker</h1>
-      <textarea
-        className="w-full border rounded p-2 h-40"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder="Enter text here"
-      />
-      <div className="text-sm text-gray-600 space-y-1">
-        <div>Length: {text.length.toLocaleString()} characters</div>
-        <div>UTF-8 Bytes: {utf8ByteCount(text).toLocaleString()}</div>
-        <div>UTF-8 Size: {formatUtf8ByteSize(text)}</div>
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">UTF-8 Length Checker</h1>
+      <div className="space-y-4">
+        <div>
+          <label className="block font-medium mb-2" htmlFor="text-input">
+            Text:
+          </label>
+          <textarea
+            id="text-input"
+            className="w-full border rounded p-2 h-40"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Enter text here"
+          />
+        </div>
+
+        <div className="text-sm text-gray-600 space-y-1">
+          <div>Length: {text.length.toLocaleString()} characters</div>
+          <div>UTF-8 Size: {formatUtf8ByteSize(text)}</div>
+        </div>
       </div>
     </div>
+  );
+}
+
+export default function StringLengthPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="p-4 max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">UTF-8 Length Checker</h1>
+          <div>Loading...</div>
+        </div>
+      }
+    >
+      <StringLengthChecker />
+    </Suspense>
   );
 }

--- a/app/string-length/page.tsx
+++ b/app/string-length/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { formatUtf8ByteSize, utf8ByteCount } from "../../lib/utf8";
+
+export default function StringLengthPage() {
+  const [text, setText] = useState("");
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">UTF-8 Length Checker</h1>
+      <textarea
+        className="w-full border rounded p-2 h-40"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Enter text here"
+      />
+      <div className="text-sm text-gray-600 space-y-1">
+        <div>Length: {text.length.toLocaleString()} characters</div>
+        <div>UTF-8 Bytes: {utf8ByteCount(text).toLocaleString()}</div>
+        <div>UTF-8 Size: {formatUtf8ByteSize(text)}</div>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -1,0 +1,147 @@
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type QueryParamValue = string | number | boolean;
+
+interface QueryParamConfig<T extends QueryParamValue> {
+  key: string;
+  defaultValue: T;
+  serialize: (value: T) => string;
+  deserialize: (value: string | null) => T;
+}
+
+/**
+ * Custom hook for managing URL query parameters with automatic synchronization.
+ * Provides a state value and setter that automatically updates the URL when changed.
+ */
+export function useQueryParam<T extends QueryParamValue>(
+  config: QueryParamConfig<T>,
+): [T, (value: T) => void] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Initialize state with URL value or default
+  const initialValue = config.deserialize(searchParams.get(config.key));
+  const [value, setValue] = useState<T>(initialValue);
+
+  // Update URL when value changes
+  useEffect(() => {
+    const currentUrlValue = config.deserialize(searchParams.get(config.key));
+
+    if (value !== currentUrlValue) {
+      const params = new URLSearchParams(searchParams);
+
+      if (value === config.defaultValue) {
+        // Remove param if it's the default value to keep URLs clean
+        params.delete(config.key);
+      } else {
+        params.set(config.key, config.serialize(value));
+      }
+
+      const queryString = params.toString();
+      router.replace(
+        queryString ? `?${queryString}` : window.location.pathname,
+        {
+          scroll: false,
+        },
+      );
+    }
+  }, [value, config, router, searchParams]);
+
+  return [value, setValue];
+}
+
+/**
+ * Custom hook for managing multiple query parameters at once.
+ * Useful when you need to update multiple parameters together to avoid multiple URL updates.
+ */
+export function useQueryParams<
+  T extends Record<string, QueryParamValue>,
+>(configs: { [K in keyof T]: QueryParamConfig<T[K]> }): [
+  T,
+  (updates: Partial<T>) => void,
+] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Initialize state with URL values or defaults
+  const initialState = Object.entries(configs).reduce((acc, [key, config]) => {
+    const typedConfig = config as QueryParamConfig<T[keyof T]>;
+    acc[key as keyof T] = typedConfig.deserialize(
+      searchParams.get(typedConfig.key),
+    );
+    return acc;
+  }, {} as T);
+
+  const [values, setValues] = useState<T>(initialState);
+
+  // Update URL when any value changes
+  useEffect(() => {
+    const params = new URLSearchParams();
+    let hasChanges = false;
+
+    // Check if any value differs from current URL params
+    for (const [key, config] of Object.entries(configs)) {
+      const typedConfig = config as QueryParamConfig<T[keyof T]>;
+      const currentValue = values[key as keyof T];
+      const urlValue = typedConfig.deserialize(
+        searchParams.get(typedConfig.key),
+      );
+
+      if (currentValue !== urlValue) {
+        hasChanges = true;
+      }
+
+      if (currentValue !== typedConfig.defaultValue) {
+        params.set(typedConfig.key, typedConfig.serialize(currentValue));
+      }
+    }
+
+    if (hasChanges) {
+      const queryString = params.toString();
+      router.replace(
+        queryString ? `?${queryString}` : window.location.pathname,
+        {
+          scroll: false,
+        },
+      );
+    }
+  }, [values, configs, router, searchParams]);
+
+  const updateValues = (updates: Partial<T>) => {
+    setValues((prev) => ({ ...prev, ...updates }));
+  };
+
+  return [values, updateValues];
+}
+
+// Helper functions for common parameter types
+export const stringParam = (
+  key: string,
+  defaultValue: string = "",
+): QueryParamConfig<string> => ({
+  key,
+  defaultValue,
+  serialize: (value) => value,
+  deserialize: (value) => value || defaultValue,
+});
+
+export const numberParam = (
+  key: string,
+  defaultValue: number = 0,
+): QueryParamConfig<number> => ({
+  key,
+  defaultValue,
+  serialize: (value) => value.toString(),
+  deserialize: (value) => Number(value) || defaultValue,
+});
+
+export const booleanParam = (
+  key: string,
+  defaultValue: boolean = false,
+): QueryParamConfig<boolean> => ({
+  key,
+  defaultValue,
+  serialize: (value) => (value ? "true" : "false"),
+  deserialize: (value) => value === "true",
+});

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -31,7 +31,10 @@ export const categories: NavigationCategory[] = [
   },
   {
     title: "Tools",
-    items: [{ name: "Random String", href: "/random-string", emoji: "🎲" }],
+    items: [
+      { name: "Random String", href: "/random-string", emoji: "🎲" },
+      { name: "UTF-8 Length", href: "/string-length", emoji: "🔤" },
+    ],
   },
 ];
 

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -33,7 +33,11 @@ export const categories: NavigationCategory[] = [
     title: "Tools",
     items: [
       { name: "Random String", href: "/random-string", emoji: "🎲" },
-      { name: "UTF-8 Length", href: "/string-length", emoji: "🔤" },
+      {
+        name: "UTF-8 Length and Byte Count",
+        href: "/string-length",
+        emoji: "🔤",
+      },
     ],
   },
 ];

--- a/lib/utf8.ts
+++ b/lib/utf8.ts
@@ -1,0 +1,19 @@
+export function utf8ByteCount(str: string): number {
+  return new TextEncoder().encode(str).length;
+}
+
+export function formatByteSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} bytes`;
+  }
+  if (bytes < 1024 * 1024) {
+    const kb = bytes / 1024;
+    return `${kb.toFixed(kb >= 100 ? 0 : kb >= 10 ? 1 : 2)} KB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(mb >= 100 ? 0 : mb >= 10 ? 1 : 2)} MB`;
+}
+
+export function formatUtf8ByteSize(str: string): string {
+  return formatByteSize(utf8ByteCount(str));
+}

--- a/lib/utf8.ts
+++ b/lib/utf8.ts
@@ -8,12 +8,15 @@ export function formatByteSize(bytes: number): string {
   }
   if (bytes < 1024 * 1024) {
     const kb = bytes / 1024;
-    return `${kb.toFixed(kb >= 100 ? 0 : kb >= 10 ? 1 : 2)} KB`;
+    return `${kb.toFixed(getDecimalPlaces(kb))} KB`;
   }
   const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(mb >= 100 ? 0 : mb >= 10 ? 1 : 2)} MB`;
+  return `${mb.toFixed(getDecimalPlaces(mb))} MB`;
 }
 
+function getDecimalPlaces(value: number): number {
+  return value >= 100 ? 0 : value >= 10 ? 1 : 2;
+}
 export function formatUtf8ByteSize(str: string): string {
   return formatByteSize(utf8ByteCount(str));
 }


### PR DESCRIPTION
## Summary
- add general UTF-8 helpers
- use helper in random string tool
- create UTF‑8 Length page
- expose page in navigation
- test UTF‑8 utilities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688488465094832e8593fdc9260ce899