### PR TITLE
Add interactive music sequencer

### DIFF
--- a/__tests__/music-sequencer-util.spec.ts
+++ b/__tests__/music-sequencer-util.spec.ts
@@ -2,6 +2,8 @@ import {
   encodeBeat,
   decodeBeat,
   defaultBeat,
+  Beat,
+  NUM_STEPS,
 } from "../app/music-sequencer/util";
 
 describe("music sequencer util", () => {
@@ -12,5 +14,39 @@ describe("music sequencer util", () => {
 
   test("invalid decode returns default", () => {
     expect(decodeBeat("not-base64")).toEqual(defaultBeat);
+  });
+
+  test("compact encoding is more efficient", () => {
+    // Create a beat with some active notes
+    const testBeat: Beat = {
+      bpm: 140,
+      synth: Array.from({ length: 12 }, () => Array(NUM_STEPS).fill(false)),
+      drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+    };
+
+    // Add a few active notes
+    testBeat.synth[0][0] = true; // C4 on step 1
+    testBeat.synth[5][4] = true; // F4 on step 5
+    testBeat.drums[0][0] = true; // Kick on step 1
+    testBeat.drums[1][8] = true; // Snare on step 9
+
+    const encoded = encodeBeat(testBeat);
+    const decoded = decodeBeat(encoded);
+
+    // Should decode correctly
+    expect(decoded).toEqual(testBeat);
+
+    // The encoded string should be much shorter than the old format
+    // (The old format would be ~1000+ characters, new should be <200)
+    expect(encoded.length).toBeLessThan(200);
+  });
+
+  test("handles empty beat efficiently", () => {
+    const encoded = encodeBeat(defaultBeat);
+    const decoded = decodeBeat(encoded);
+    
+    expect(decoded).toEqual(defaultBeat);
+    // Empty beat should be very short
+    expect(encoded.length).toBeLessThan(100);
   });
 });

--- a/__tests__/music-sequencer-util.spec.ts
+++ b/__tests__/music-sequencer-util.spec.ts
@@ -1,0 +1,16 @@
+import {
+  encodeBeat,
+  decodeBeat,
+  defaultBeat,
+} from "../app/music-sequencer/util";
+
+describe("music sequencer util", () => {
+  test("encodes and decodes beat", () => {
+    const encoded = encodeBeat(defaultBeat);
+    expect(decodeBeat(encoded)).toEqual(defaultBeat);
+  });
+
+  test("invalid decode returns default", () => {
+    expect(decodeBeat("not-base64")).toEqual(defaultBeat);
+  });
+});

--- a/__tests__/music-sequencer-util.spec.ts
+++ b/__tests__/music-sequencer-util.spec.ts
@@ -17,11 +17,13 @@ describe("music sequencer util", () => {
   });
 
   test("compact encoding is more efficient", () => {
-    // Create a beat with some active notes
+    // Create a beat with some active notes that matches the current structure
     const testBeat: Beat = {
       bpm: 140,
-      synth: Array.from({ length: 12 }, () => Array(NUM_STEPS).fill(false)),
+      synth: Array.from({ length: 24 }, () => Array(NUM_STEPS).fill(false)), // 24 notes for 2 octaves
       drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+      rootNote: "C",
+      scale: "chromatic",
     };
 
     // Add a few active notes

--- a/app/music-sequencer/Sequencer.tsx
+++ b/app/music-sequencer/Sequencer.tsx
@@ -2,7 +2,20 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryParam } from "../../hooks/useQueryParams";
-import { Beat, NUM_STEPS, defaultBeat, encodeBeat, decodeBeat } from "./util";
+import { 
+  Beat, 
+  NUM_STEPS, 
+  defaultBeat, 
+  encodeBeat, 
+  decodeBeat, 
+  beatToCompact, 
+  compactToBeat,
+  SCALE_NAMES,
+  ROOT_NOTES,
+  ScaleName,
+  getScaleNotes,
+  transposeBeatToScale
+} from "./util";
 
 const NOTE_NAMES = [
   "C",
@@ -49,11 +62,44 @@ export default function Sequencer() {
   const [currentStep, setCurrentStep] = useState(0);
   const [showJson, setShowJson] = useState(false);
   const [jsonText, setJsonText] = useState("");
+  const [playingNotes, setPlayingNotes] = useState<Set<string>>(new Set());
+   const [urlCopied, setUrlCopied] = useState(false);
+  
+  // Initialize scale settings from the loaded beat
+  const [selectedScale, setSelectedScale] = useState<ScaleName>(() => {
+    const loadedBeat = decodeBeat(encodedBeat);
+    return loadedBeat.scale || "chromatic";
+  });
+  const [rootNote, setRootNote] = useState(() => {
+    const loadedBeat = decodeBeat(encodedBeat);
+    return loadedBeat.rootNote || "C";
+  });
 
   const audioCtxRef = useRef<AudioContext | null>(null);
 
+  // Get the notes that should be visible based on selected scale
+  const visibleNoteIndices = getScaleNotes(rootNote, selectedScale) || [];
+
+  // Handler for scale changes with transposition
+  const handleScaleChange = (newScale: ScaleName) => {
+    const transposedBeat = transposeBeatToScale(beat, rootNote, newScale);
+    const updatedBeat = { ...transposedBeat, scale: newScale };
+    setBeat(updatedBeat);
+    setSelectedScale(newScale);
+  };
+
+  // Handler for root note changes with transposition
+  const handleRootNoteChange = (newRootNote: string) => {
+    const transposedBeat = transposeBeatToScale(beat, newRootNote, selectedScale);
+    const updatedBeat = { ...transposedBeat, rootNote: newRootNote };
+    setBeat(updatedBeat);
+    setRootNote(newRootNote);
+  };
+
   useEffect(() => {
-    setJsonText(JSON.stringify(beat, null, 2));
+    // Use compact format for JSON display
+    const compactBeat = beatToCompact(beat);
+    setJsonText(JSON.stringify(compactBeat, null, 2));
     setEncodedBeat(encodeBeat(beat));
   }, [beat, setEncodedBeat]);
 
@@ -66,7 +112,7 @@ export default function Sequencer() {
     return audioCtxRef.current;
   }
 
-  const playNote = useCallback((freq: number) => {
+  const playNote = useCallback((freq: number, noteIndex?: number, step?: number) => {
     const ctx = getCtx();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
@@ -78,9 +124,22 @@ export default function Sequencer() {
     gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
     osc.start();
     osc.stop(ctx.currentTime + 0.5);
+
+    // Add visual feedback for playing notes - include step for specificity
+    if (noteIndex !== undefined && step !== undefined) {
+      const noteKey = `synth-${noteIndex}-${step}`;
+      setPlayingNotes(prev => new Set(prev).add(noteKey));
+      setTimeout(() => {
+        setPlayingNotes(prev => {
+          const newSet = new Set(prev);
+          newSet.delete(noteKey);
+          return newSet;
+        });
+      }, 200); // Show for 200ms
+    }
   }, []);
 
-  const playDrum = useCallback((name: string) => {
+  const playDrum = useCallback((name: string, drumIndex?: number, step?: number) => {
     const ctx = getCtx();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
@@ -101,6 +160,19 @@ export default function Sequencer() {
     gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.2);
     osc.start();
     osc.stop(ctx.currentTime + 0.2);
+
+    // Add visual feedback for playing drums - include step for specificity
+    if (drumIndex !== undefined && step !== undefined) {
+      const drumKey = `drum-${drumIndex}-${step}`;
+      setPlayingNotes(prev => new Set(prev).add(drumKey));
+      setTimeout(() => {
+        setPlayingNotes(prev => {
+          const newSet = new Set(prev);
+          newSet.delete(drumKey);
+          return newSet;
+        });
+      }, 200); // Show for 200ms
+    }
   }, []);
 
   const toggleSynth = (noteIndex: number, step: number) => {
@@ -132,12 +204,12 @@ export default function Sequencer() {
     if (!isPlaying) return;
     beat.synth.forEach((row, noteIndex) => {
       if (row[currentStep]) {
-        playNote(NOTE_FREQUENCIES[noteIndex]);
+        playNote(NOTE_FREQUENCIES[noteIndex], noteIndex, currentStep);
       }
     });
     beat.drums.forEach((row, drumIndex) => {
       if (row[currentStep]) {
-        playDrum(DRUMS[drumIndex]);
+        playDrum(DRUMS[drumIndex], drumIndex, currentStep);
       }
     });
   }, [currentStep, isPlaying, beat, playNote, playDrum]);
@@ -160,7 +232,7 @@ export default function Sequencer() {
     const handler = (e: KeyboardEvent) => {
       const idx = keyMap[e.key];
       if (idx !== undefined) {
-        playNote(NOTE_FREQUENCIES[idx]);
+        playNote(NOTE_FREQUENCIES[idx]); // No visual feedback for keyboard notes
       }
     };
     window.addEventListener("keydown", handler);
@@ -169,28 +241,119 @@ export default function Sequencer() {
 
   const applyJson = () => {
     try {
-      const parsed = JSON.parse(jsonText) as Beat;
-      setBeat(parsed);
+      const parsed = JSON.parse(jsonText);
+      
+      let newBeat: Beat;
+      // Check if it's already a compact format
+      if (parsed.synth && Array.isArray(parsed.synth) && 
+          (parsed.synth.length === 0 || typeof parsed.synth[0] === 'number')) {
+        // It's compact format, convert to full Beat
+        newBeat = compactToBeat(parsed);
+      } else {
+        // It's full Beat format, use as-is
+        newBeat = parsed as Beat;
+      }
+      
+      setBeat(newBeat);
+      
+      // Update UI state to match the loaded beat
+      if (newBeat.rootNote) {
+        setRootNote(newBeat.rootNote);
+      }
+      if (newBeat.scale) {
+        setSelectedScale(newBeat.scale);
+      }
     } catch {
       alert("Invalid JSON");
     }
   };
 
   const copyUrl = async () => {
-    await navigator.clipboard.writeText(window.location.href);
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setUrlCopied(true);
+      // Reset the feedback after 2 seconds
+      setTimeout(() => {
+        setUrlCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error('Failed to copy URL:', error);
+      // You could add error feedback here if needed
+    }
+  };
+
+  const clearGrid = () => {
+    setBeat((prev) => ({
+      ...prev,
+      synth: Array.from({ length: 24 }, () => Array(NUM_STEPS).fill(false)), // 24 notes for 2 octaves
+      drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+      // Preserve scale settings when clearing
+      rootNote: prev.rootNote || "C",
+      scale: prev.scale || "chromatic",
+    }));
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Music Sequencer</h1>
-      <div className="flex items-center gap-2">
+    <div className="p-6 space-y-6 max-w-7xl mx-auto">
+      <h1 className="text-3xl font-bold text-center">Music Sequencer</h1>
+      
+      {/* Scale Selection */}
+      <div className="flex justify-center">
+        <div className="flex flex-wrap items-center justify-center gap-6 p-4 bg-gray-50 rounded-lg">
+          <div className="flex items-center gap-3">
+            <label htmlFor="root-note" className="text-sm font-medium">
+              Root Note:
+            </label>
+            <select
+              id="root-note"
+              value={rootNote}
+              onChange={(e) => handleRootNoteChange(e.target.value)}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              {ROOT_NOTES.map((note) => (
+                <option key={note} value={note}>
+                  {note}
+                </option>
+              ))}
+            </select>
+          </div>
+          
+          <div className="flex items-center gap-3">
+            <label htmlFor="scale" className="text-sm font-medium">
+              Scale:
+            </label>
+            <select
+              id="scale"
+              value={selectedScale}
+              onChange={(e) => handleScaleChange(e.target.value as ScaleName)}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              {Object.entries(SCALE_NAMES).map(([key, name]) => (
+                <option key={key} value={key}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+          
+          <div className="text-xs text-gray-600">
+            {selectedScale === "chromatic" 
+              ? "Showing all notes" 
+              : `Showing ${visibleNoteIndices.length} notes in ${SCALE_NAMES[selectedScale]} scale`
+            }
+          </div>
+        </div>
+      </div>
+
+      {/* Transport Controls */}
+      <div className="flex items-center justify-center gap-4 flex-wrap">
         <button
           onClick={() => setIsPlaying((p) => !p)}
-          className="px-3 py-1 bg-blue-600 text-white rounded"
+          className="px-4 py-2 bg-blue-600 text-white rounded cursor-pointer hover:bg-blue-700 transition-colors duration-150"
         >
           {isPlaying ? "Stop" : "Play"}
         </button>
-        <label className="flex items-center gap-1">
+        <label className="flex items-center gap-2">
           BPM:
           <input
             type="number"
@@ -198,75 +361,118 @@ export default function Sequencer() {
             onChange={(e) =>
               setBeat((prev) => ({ ...prev, bpm: Number(e.target.value) }))
             }
-            className="w-20 border p-1 rounded"
+            className="w-24 border p-2 rounded"
           />
         </label>
         <button
           onClick={copyUrl}
-          className="px-3 py-1 bg-gray-600 text-white rounded"
+          className={`px-4 py-2 text-white rounded cursor-pointer transition-colors duration-200 ${
+            urlCopied 
+              ? "bg-green-600 hover:bg-green-700" 
+              : "bg-gray-600 hover:bg-gray-700"
+          }`}
         >
-          Copy URL
+          {urlCopied ? "Copied!" : "Copy URL"}
         </button>
         <button
           onClick={() => setShowJson((s) => !s)}
-          className="px-3 py-1 bg-gray-600 text-white rounded"
+          className="px-4 py-2 bg-gray-600 text-white rounded cursor-pointer hover:bg-gray-700 transition-colors duration-150"
         >
           {showJson ? "Hide JSON" : "Show JSON"}
         </button>
+        <button
+          onClick={clearGrid}
+          className="px-4 py-2 bg-red-600 text-white rounded cursor-pointer hover:bg-red-700 transition-colors duration-150"
+        >
+          Clear
+        </button>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="border-collapse">
-          <tbody>
-            {beat.synth.map((row, noteIndex) => (
-              <tr key={noteIndex}>
-                <td className="pr-2 text-right text-xs text-gray-600">
-                  {SYNTH_NOTES[noteIndex]}
-                </td>
-                {row.map((active, step) => (
-                  <td
-                    key={step}
-                    onClick={() => toggleSynth(noteIndex, step)}
-                    className={`w-6 h-6 border cursor-pointer ${
-                      active ? "bg-blue-500" : "bg-white"
-                    } ${
-                      isPlaying && step === currentStep
-                        ? "border-yellow-400"
-                        : ""
-                    }`}
-                  ></td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {/* Synth Grid */}
+      <div>
+        <h3 className="text-xl font-semibold mb-3 text-center">Synth Notes</h3>
+        <div className="flex justify-center">
+          <div className="overflow-x-auto">
+            <table className="border-collapse">
+            <tbody>
+              {visibleNoteIndices.map((noteIndex) => {
+                const row = beat.synth[noteIndex];
+                return (
+                  <tr key={noteIndex} className="group">
+                    <td className="pr-3 text-right text-sm font-medium text-gray-700 group-hover:text-blue-600 group-hover:font-bold transition-colors duration-150 min-w-[3rem]">
+                      {SYNTH_NOTES[noteIndex]}
+                    </td>
+                    {row.map((active, step) => {
+                      const isCurrentStep = isPlaying && step === currentStep;
+                      const isPlayingNote = playingNotes.has(`synth-${noteIndex}-${step}`);
+                      
+                      return (
+                        <td
+                          key={step}
+                          onClick={() => toggleSynth(noteIndex, step)}
+                          className={`w-10 h-10 border-2 cursor-pointer transition-all duration-150 hover:border-blue-400 hover:shadow-md ${
+                            active ? "bg-blue-500 hover:bg-blue-600" : "bg-white hover:bg-blue-50"
+                          } ${
+                            isCurrentStep
+                              ? "border-orange-400 shadow-lg bg-orange-100"
+                              : "border-gray-300"
+                          } ${
+                            isPlayingNote && active
+                              ? "bg-yellow-300 ring-2 ring-yellow-400"
+                              : ""
+                          }`}
+                        ></td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          </div>
+        </div>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="border-collapse mt-4">
-          <tbody>
-            {beat.drums.map((row, drumIndex) => (
-              <tr key={drumIndex}>
-                <td className="pr-2 text-right text-xs text-gray-600">
-                  {DRUMS[drumIndex]}
-                </td>
-                {row.map((active, step) => (
-                  <td
-                    key={step}
-                    onClick={() => toggleDrum(drumIndex, step)}
-                    className={`w-6 h-6 border cursor-pointer ${
-                      active ? "bg-green-500" : "bg-white"
-                    } ${
-                      isPlaying && step === currentStep
-                        ? "border-yellow-400"
-                        : ""
-                    }`}
-                  ></td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {/* Drum Grid */}
+      <div>
+        <h3 className="text-xl font-semibold mb-3 text-center">Drums</h3>
+        <div className="flex justify-center">
+          <div className="overflow-x-auto">
+            <table className="border-collapse">
+            <tbody>
+              {beat.drums.map((row, drumIndex) => (
+                <tr key={drumIndex} className="group">
+                  <td className="pr-3 text-right text-sm font-medium text-gray-700 group-hover:text-green-600 group-hover:font-bold transition-colors duration-150 min-w-[3rem]">
+                    {DRUMS[drumIndex]}
+                  </td>
+                  {row.map((active, step) => {
+                    const isCurrentStep = isPlaying && step === currentStep;
+                    const isPlayingDrum = playingNotes.has(`drum-${drumIndex}-${step}`);
+                    
+                    return (
+                      <td
+                        key={step}
+                        onClick={() => toggleDrum(drumIndex, step)}
+                        className={`w-10 h-10 border-2 cursor-pointer transition-all duration-150 hover:border-green-400 hover:shadow-md ${
+                          active ? "bg-green-500 hover:bg-green-600" : "bg-white hover:bg-green-50"
+                        } ${
+                          isCurrentStep
+                            ? "border-orange-400 shadow-lg bg-orange-100"
+                            : "border-gray-300"
+                        } ${
+                          isPlayingDrum && active
+                            ? "bg-yellow-300 ring-2 ring-yellow-400"
+                            : ""
+                        }`}
+                      ></td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+        </div>
       </div>
 
       {showJson && (
@@ -278,7 +484,7 @@ export default function Sequencer() {
           />
           <button
             onClick={applyJson}
-            className="px-3 py-1 bg-blue-600 text-white rounded"
+            className="px-3 py-1 bg-blue-600 text-white rounded cursor-pointer"
           >
             Update From JSON
           </button>

--- a/app/music-sequencer/Sequencer.tsx
+++ b/app/music-sequencer/Sequencer.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryParam } from "../../hooks/useQueryParams";
+import { Beat, NUM_STEPS, defaultBeat, encodeBeat, decodeBeat } from "./util";
+
+const NOTE_NAMES = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+const OCTAVES = [4, 5];
+const SYNTH_NOTES = OCTAVES.flatMap((oct) =>
+  NOTE_NAMES.map((n) => `${n}${oct}`),
+);
+const DRUMS = ["Kick", "Snare", "Hat"];
+
+function noteToFrequency(note: string): number {
+  const match = note.match(/([A-G]#?)(\d)/);
+  if (!match) return 440;
+  const [, name, octaveStr] = match;
+  const octave = parseInt(octaveStr, 10);
+  const semitone = NOTE_NAMES.indexOf(name);
+  const midi = (octave + 1) * 12 + semitone;
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+const NOTE_FREQUENCIES = SYNTH_NOTES.map(noteToFrequency);
+
+export default function Sequencer() {
+  const [encodedBeat, setEncodedBeat] = useQueryParam({
+    key: "beat",
+    defaultValue: encodeBeat(defaultBeat),
+    serialize: (v: string) => v,
+    deserialize: (v: string | null) => v || encodeBeat(defaultBeat),
+  });
+
+  const [beat, setBeat] = useState<Beat>(() => decodeBeat(encodedBeat));
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [showJson, setShowJson] = useState(false);
+  const [jsonText, setJsonText] = useState("");
+
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  useEffect(() => {
+    setJsonText(JSON.stringify(beat, null, 2));
+    setEncodedBeat(encodeBeat(beat));
+  }, [beat, setEncodedBeat]);
+
+  function getCtx(): AudioContext {
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new (window.AudioContext ||
+        // @ts-ignore
+        window.webkitAudioContext)();
+    }
+    return audioCtxRef.current;
+  }
+
+  const playNote = useCallback((freq: number) => {
+    const ctx = getCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "square";
+    osc.frequency.value = freq;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    gain.gain.setValueAtTime(0.2, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.5);
+  }, []);
+
+  const playDrum = useCallback((name: string) => {
+    const ctx = getCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    if (name === "Kick") {
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(150, ctx.currentTime);
+      osc.frequency.exponentialRampToValueAtTime(50, ctx.currentTime + 0.5);
+    } else if (name === "Snare") {
+      osc.type = "triangle";
+      osc.frequency.setValueAtTime(200, ctx.currentTime);
+    } else {
+      osc.type = "square";
+      osc.frequency.setValueAtTime(400, ctx.currentTime);
+    }
+    gain.gain.setValueAtTime(0.2, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.2);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.2);
+  }, []);
+
+  const toggleSynth = (noteIndex: number, step: number) => {
+    setBeat((prev) => {
+      const synth = prev.synth.map((row) => row.slice());
+      synth[noteIndex][step] = !synth[noteIndex][step];
+      return { ...prev, synth };
+    });
+  };
+
+  const toggleDrum = (drumIndex: number, step: number) => {
+    setBeat((prev) => {
+      const drums = prev.drums.map((row) => row.slice());
+      drums[drumIndex][step] = !drums[drumIndex][step];
+      return { ...prev, drums };
+    });
+  };
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    const interval = (60 / beat.bpm / 4) * 1000;
+    const id = setInterval(() => {
+      setCurrentStep((s) => (s + 1) % NUM_STEPS);
+    }, interval);
+    return () => clearInterval(id);
+  }, [isPlaying, beat.bpm]);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    beat.synth.forEach((row, noteIndex) => {
+      if (row[currentStep]) {
+        playNote(NOTE_FREQUENCIES[noteIndex]);
+      }
+    });
+    beat.drums.forEach((row, drumIndex) => {
+      if (row[currentStep]) {
+        playDrum(DRUMS[drumIndex]);
+      }
+    });
+  }, [currentStep, isPlaying, beat, playNote, playDrum]);
+
+  useEffect(() => {
+    const keyMap: Record<string, number> = {
+      a: 0,
+      w: 1,
+      s: 2,
+      e: 3,
+      d: 4,
+      f: 5,
+      t: 6,
+      g: 7,
+      y: 8,
+      h: 9,
+      u: 10,
+      j: 11,
+    };
+    const handler = (e: KeyboardEvent) => {
+      const idx = keyMap[e.key];
+      if (idx !== undefined) {
+        playNote(NOTE_FREQUENCIES[idx]);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [playNote]);
+
+  const applyJson = () => {
+    try {
+      const parsed = JSON.parse(jsonText) as Beat;
+      setBeat(parsed);
+    } catch {
+      alert("Invalid JSON");
+    }
+  };
+
+  const copyUrl = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Music Sequencer</h1>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setIsPlaying((p) => !p)}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          {isPlaying ? "Stop" : "Play"}
+        </button>
+        <label className="flex items-center gap-1">
+          BPM:
+          <input
+            type="number"
+            value={beat.bpm}
+            onChange={(e) =>
+              setBeat((prev) => ({ ...prev, bpm: Number(e.target.value) }))
+            }
+            className="w-20 border p-1 rounded"
+          />
+        </label>
+        <button
+          onClick={copyUrl}
+          className="px-3 py-1 bg-gray-600 text-white rounded"
+        >
+          Copy URL
+        </button>
+        <button
+          onClick={() => setShowJson((s) => !s)}
+          className="px-3 py-1 bg-gray-600 text-white rounded"
+        >
+          {showJson ? "Hide JSON" : "Show JSON"}
+        </button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="border-collapse">
+          <tbody>
+            {beat.synth.map((row, noteIndex) => (
+              <tr key={noteIndex}>
+                <td className="pr-2 text-right text-xs text-gray-600">
+                  {SYNTH_NOTES[noteIndex]}
+                </td>
+                {row.map((active, step) => (
+                  <td
+                    key={step}
+                    onClick={() => toggleSynth(noteIndex, step)}
+                    className={`w-6 h-6 border cursor-pointer ${
+                      active ? "bg-blue-500" : "bg-white"
+                    } ${
+                      isPlaying && step === currentStep
+                        ? "border-yellow-400"
+                        : ""
+                    }`}
+                  ></td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="border-collapse mt-4">
+          <tbody>
+            {beat.drums.map((row, drumIndex) => (
+              <tr key={drumIndex}>
+                <td className="pr-2 text-right text-xs text-gray-600">
+                  {DRUMS[drumIndex]}
+                </td>
+                {row.map((active, step) => (
+                  <td
+                    key={step}
+                    onClick={() => toggleDrum(drumIndex, step)}
+                    className={`w-6 h-6 border cursor-pointer ${
+                      active ? "bg-green-500" : "bg-white"
+                    } ${
+                      isPlaying && step === currentStep
+                        ? "border-yellow-400"
+                        : ""
+                    }`}
+                  ></td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {showJson && (
+        <div className="space-y-2">
+          <textarea
+            className="w-full h-40 border p-2 font-mono text-sm"
+            value={jsonText}
+            onChange={(e) => setJsonText(e.target.value)}
+          />
+          <button
+            onClick={applyJson}
+            className="px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            Update From JSON
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/music-sequencer/page.tsx
+++ b/app/music-sequencer/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import Sequencer from "./Sequencer";
+
+export default function MusicSequencerPage() {
+  return (
+    <Suspense fallback={<div className="p-4">Loading...</div>}>
+      <Sequencer />
+    </Suspense>
+  );
+}

--- a/app/music-sequencer/util.ts
+++ b/app/music-sequencer/util.ts
@@ -1,0 +1,35 @@
+export interface Beat {
+  bpm: number;
+  synth: boolean[][];
+  drums: boolean[][];
+}
+
+export const NUM_STEPS = 16;
+
+export const defaultBeat: Beat = {
+  bpm: 120,
+  synth: Array.from({ length: 12 }, () => Array(NUM_STEPS).fill(false)),
+  drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+};
+
+export function encodeBeat(beat: Beat): string {
+  const json = JSON.stringify(beat);
+  if (typeof btoa === "function") {
+    return btoa(json);
+  }
+  // Node.js fallback
+  return Buffer.from(json, "utf8").toString("base64");
+}
+
+export function decodeBeat(str: string | null): Beat {
+  if (!str) return defaultBeat;
+  try {
+    const json =
+      typeof atob === "function"
+        ? atob(str)
+        : Buffer.from(str, "base64").toString("utf8");
+    return JSON.parse(json) as Beat;
+  } catch {
+    return defaultBeat;
+  }
+}

--- a/app/music-sequencer/util.ts
+++ b/app/music-sequencer/util.ts
@@ -2,18 +2,203 @@ export interface Beat {
   bpm: number;
   synth: boolean[][];
   drums: boolean[][];
+  rootNote?: string; // Optional for backwards compatibility
+  scale?: ScaleName; // Optional for backwards compatibility
+}
+
+// Scale definitions - semitone intervals from root note
+export const SCALES = {
+  chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], // All notes
+  major: [0, 2, 4, 5, 7, 9, 11], // Major scale
+  minor: [0, 2, 3, 5, 7, 8, 10], // Natural minor scale
+  pentatonic_major: [0, 2, 4, 7, 9], // Major pentatonic
+  pentatonic_minor: [0, 3, 5, 7, 10], // Minor pentatonic
+  blues: [0, 3, 5, 6, 7, 10], // Blues scale
+  dorian: [0, 2, 3, 5, 7, 9, 10], // Dorian mode
+  mixolydian: [0, 2, 4, 5, 7, 9, 10], // Mixolydian mode
+  harmonic_minor: [0, 2, 3, 5, 7, 8, 11], // Harmonic minor
+} as const;
+
+export type ScaleName = keyof typeof SCALES;
+
+export const SCALE_NAMES: Record<ScaleName, string> = {
+  chromatic: "Chromatic (All Notes)",
+  major: "Major",
+  minor: "Minor",
+  pentatonic_major: "Pentatonic Major",
+  pentatonic_minor: "Pentatonic Minor",
+  blues: "Blues",
+  dorian: "Dorian",
+  mixolydian: "Mixolydian",
+  harmonic_minor: "Harmonic Minor",
+};
+
+// Root note options (C, C#, D, etc.)
+export const ROOT_NOTES = [
+  "C", "C#", "D", "D#", "E", "F", 
+  "F#", "G", "G#", "A", "A#", "B"
+];
+
+// Generate note indices for a given scale and root
+export function getScaleNotes(rootNote: string, scaleName: ScaleName): number[] {
+  const rootIndex = ROOT_NOTES.indexOf(rootNote);
+  if (rootIndex === -1) return [];
+  
+  const scaleIntervals = SCALES[scaleName];
+  const scaleNotes: number[] = [];
+  
+  // Generate notes across two octaves (24 semitones total)
+  for (let octave = 0; octave < 2; octave++) {
+    scaleIntervals.forEach(interval => {
+      const noteIndex = (rootIndex + interval + octave * 12) % 24;
+      if (noteIndex < 24) { // We have 24 synth notes (2 octaves)
+        scaleNotes.push(noteIndex);
+      }
+    });
+  }
+  
+  return scaleNotes.sort((a, b) => a - b);
+}
+
+// Find the nearest note in a scale for transposition
+export function findNearestScaleNote(noteIndex: number, scaleNotes: number[]): number {
+  if (scaleNotes.includes(noteIndex)) {
+    return noteIndex; // Note is already in scale
+  }
+  
+  // Find the closest note in the scale
+  let minDistance = Infinity;
+  let nearestNote = scaleNotes[0];
+  
+  for (const scaleNote of scaleNotes) {
+    const distance = Math.abs(noteIndex - scaleNote);
+    if (distance < minDistance) {
+      minDistance = distance;
+      nearestNote = scaleNote;
+    }
+  }
+  
+  return nearestNote;
+}
+
+// Transpose beat to fit a new scale
+export function transposeBeatToScale(beat: Beat, rootNote: string, scaleName: ScaleName): Beat {
+  const scaleNotes = getScaleNotes(rootNote, scaleName);
+  
+  // If chromatic scale, no transposition needed
+  if (scaleName === 'chromatic') {
+    return beat;
+  }
+  
+  const newBeat: Beat = {
+    ...beat,
+    synth: Array.from({ length: 24 }, () => Array(NUM_STEPS).fill(false)),
+    drums: beat.drums.map(row => [...row]), // Copy drums unchanged
+  };
+  
+  // Transpose synth notes
+  beat.synth.forEach((row, noteIndex) => {
+    row.forEach((active, step) => {
+      if (active) {
+        const transposedNote = findNearestScaleNote(noteIndex, scaleNotes);
+        newBeat.synth[transposedNote][step] = true;
+      }
+    });
+  });
+  
+  return newBeat;
+}
+
+// Compact representation for URL encoding
+interface CompactBeat {
+  bpm: number;
+  synth: number[]; // Array of indices where synth[noteIndex][step] is true
+  drums: number[]; // Array of indices where drums[drumIndex][step] is true
+  rootNote?: string; // Optional for backwards compatibility
+  scale?: ScaleName; // Optional for backwards compatibility
 }
 
 export const NUM_STEPS = 16;
 
 export const defaultBeat: Beat = {
   bpm: 120,
-  synth: Array.from({ length: 12 }, () => Array(NUM_STEPS).fill(false)),
+  synth: Array.from({ length: 24 }, () => Array(NUM_STEPS).fill(false)), // 24 notes for 2 octaves
   drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+  rootNote: "C",
+  scale: "chromatic",
 };
 
+// Convert Beat to CompactBeat format
+export function beatToCompact(beat: Beat): CompactBeat {
+  const compactBeat: CompactBeat = {
+    bpm: beat.bpm,
+    synth: [],
+    drums: [],
+    rootNote: beat.rootNote,
+    scale: beat.scale,
+  };
+
+  // Encode synth notes: combine noteIndex and step into single number
+  beat.synth.forEach((row, noteIndex) => {
+    row.forEach((active, step) => {
+      if (active) {
+        // Encode as noteIndex * NUM_STEPS + step
+        compactBeat.synth.push(noteIndex * NUM_STEPS + step);
+      }
+    });
+  });
+
+  // Encode drums: combine drumIndex and step into single number
+  beat.drums.forEach((row, drumIndex) => {
+    row.forEach((active, step) => {
+      if (active) {
+        // Encode as drumIndex * NUM_STEPS + step
+        compactBeat.drums.push(drumIndex * NUM_STEPS + step);
+      }
+    });
+  });
+
+  return compactBeat;
+}
+
+// Convert CompactBeat to Beat format
+export function compactToBeat(compactBeat: CompactBeat): Beat {
+  const beat: Beat = {
+    bpm: compactBeat.bpm || 120,
+    synth: Array.from({ length: 24 }, () => Array(NUM_STEPS).fill(false)), // 24 notes for 2 octaves
+    drums: Array.from({ length: 3 }, () => Array(NUM_STEPS).fill(false)),
+    rootNote: compactBeat.rootNote || "C",
+    scale: compactBeat.scale || "chromatic",
+  };
+
+  // Decode synth notes
+  if (compactBeat.synth) {
+    compactBeat.synth.forEach((encoded) => {
+      const noteIndex = Math.floor(encoded / NUM_STEPS);
+      const step = encoded % NUM_STEPS;
+      if (noteIndex >= 0 && noteIndex < 24 && step >= 0 && step < NUM_STEPS) { // Updated to 24
+        beat.synth[noteIndex][step] = true;
+      }
+    });
+  }
+
+  // Decode drums
+  if (compactBeat.drums) {
+    compactBeat.drums.forEach((encoded) => {
+      const drumIndex = Math.floor(encoded / NUM_STEPS);
+      const step = encoded % NUM_STEPS;
+      if (drumIndex >= 0 && drumIndex < 3 && step >= 0 && step < NUM_STEPS) {
+        beat.drums[drumIndex][step] = true;
+      }
+    });
+  }
+
+  return beat;
+}
+
 export function encodeBeat(beat: Beat): string {
-  const json = JSON.stringify(beat);
+  const compactBeat = beatToCompact(beat);
+  const json = JSON.stringify(compactBeat);
   if (typeof btoa === "function") {
     return btoa(json);
   }
@@ -23,12 +208,24 @@ export function encodeBeat(beat: Beat): string {
 
 export function decodeBeat(str: string | null): Beat {
   if (!str) return defaultBeat;
+  
   try {
     const json =
       typeof atob === "function"
         ? atob(str)
         : Buffer.from(str, "base64").toString("utf8");
-    return JSON.parse(json) as Beat;
+    
+    const compactBeat = JSON.parse(json) as CompactBeat;
+    
+    // Handle legacy format (full Beat object)
+    if ('synth' in compactBeat && Array.isArray(compactBeat.synth) && 
+        compactBeat.synth.length > 0 && Array.isArray(compactBeat.synth[0])) {
+      // This is the old format, return as-is
+      return compactBeat as unknown as Beat;
+    }
+    
+    // Convert from compact format back to full format
+    return compactToBeat(compactBeat);
   } catch {
     return defaultBeat;
   }

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -38,7 +38,7 @@ export const categories: NavigationCategory[] = [
         href: "/string-length",
         emoji: "🔤",
       },
-      { name: "Music Sequencer", href: "/music-sequencer", emoji: "🎶" },
+      { name: "Sequencer", href: "/music-sequencer?beat=eyJicG0iOjEyMCwic3ludGgiOlswLDgzLDEyNSwxOTgsMjQ5LDMxOCwzNjNdLCJkcnVtcyI6WzAsNCwxMiwyNCwyNSwyNiwyN10sInJvb3ROb3RlIjoiQyIsInNjYWxlIjoicGVudGF0b25pY19taW5vciJ9", emoji: "🎶" },
     ],
   },
 ];

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -38,6 +38,7 @@ export const categories: NavigationCategory[] = [
         href: "/string-length",
         emoji: "🔤",
       },
+      { name: "Music Sequencer", href: "/music-sequencer", emoji: "🎶" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- add shareable music sequencer with synth, drums, keyboard controls and JSON editing
- expose sequencing utilities and tests
- surface sequencer from the site's navigation

## Testing
- `npm run prettier:fix`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f88388600832ea125c7fb9ce3993a