### PR TITLE
fix(deadlock-parry): anchor parry window to windup cue start

### DIFF
--- a/__tests__/deadlock-parry.spec.ts
+++ b/__tests__/deadlock-parry.spec.ts
@@ -8,21 +8,21 @@ import {
 describe("evaluateParryPress", () => {
   const settings = { windupDurationMs: 700, parryWindowMs: 500 };
   const windupStart = 1000;
-  // connect time = 1700; parry window = [1200, 1700]
+  // parry window = [1000, 1500] (deadline 500ms after windup cue)
 
   test("press inside parry window → success", () => {
-    expect(evaluateParryPress(1300, windupStart, settings)).toBe("success");
-    expect(evaluateParryPress(1200, windupStart, settings)).toBe("success");
-    expect(evaluateParryPress(1700, windupStart, settings)).toBe("success");
+    expect(evaluateParryPress(1000, windupStart, settings)).toBe("success");
+    expect(evaluateParryPress(1250, windupStart, settings)).toBe("success");
+    expect(evaluateParryPress(1500, windupStart, settings)).toBe("success");
   });
 
-  test("press before parry window → too-early", () => {
-    expect(evaluateParryPress(1000, windupStart, settings)).toBe("too-early");
-    expect(evaluateParryPress(1199, windupStart, settings)).toBe("too-early");
+  test("press before windup cue → too-early", () => {
+    expect(evaluateParryPress(999, windupStart, settings)).toBe("too-early");
+    expect(evaluateParryPress(500, windupStart, settings)).toBe("too-early");
   });
 
-  test("press after connect → miss", () => {
-    expect(evaluateParryPress(1701, windupStart, settings)).toBe("miss");
+  test("press after parry window → miss", () => {
+    expect(evaluateParryPress(1501, windupStart, settings)).toBe("miss");
     expect(evaluateParryPress(5000, windupStart, settings)).toBe("miss");
   });
 
@@ -64,8 +64,8 @@ describe("makeOutcome", () => {
   });
   test("early press → too-early", () => {
     expect(
-      makeOutcome({ pressed: true, pressTimeMs: 1100 }, 1000, settings),
-    ).toEqual({ kind: "too-early", reactionMs: 100 });
+      makeOutcome({ pressed: true, pressTimeMs: 900 }, 1000, settings),
+    ).toEqual({ kind: "too-early", reactionMs: 0 });
   });
   test("late press → hit", () => {
     expect(

--- a/app/deadlock-parry/util.ts
+++ b/app/deadlock-parry/util.ts
@@ -8,8 +8,7 @@ export type ParrySettings = {
 export const DEFAULT_SETTINGS: ParrySettings = {
   // Upstream reference implementation (apxsta/ParryTrainer) treats the heavy
   // melee alert as the start of a 1.2s reaction deadline — any F-press within
-  // that window counts as a parry. We match that model by setting the window
-  // equal to the windup duration (no "too-early" state by default).
+  // that window counts as a parry.
   // Source: https://github.com/apxsta/ParryTrainer (RESPONSE_TIME = 1.2).
   windupDurationMs: 1200,
   parryWindowMs: 1200,
@@ -20,10 +19,11 @@ export function evaluateParryPress(
   windupStartMs: number,
   settings: ParrySettings,
 ): ParryResult {
-  const connectTime = windupStartMs + settings.windupDurationMs;
-  const windowStart = connectTime - settings.parryWindowMs;
-  if (pressTimeMs < windowStart) return "too-early";
-  if (pressTimeMs > connectTime) return "miss";
+  // The parry window is a reaction deadline that starts at the windup cue.
+  // A press is valid anywhere in [windupStart, windupStart + parryWindow].
+  const windowEnd = windupStartMs + settings.parryWindowMs;
+  if (pressTimeMs < windupStartMs) return "too-early";
+  if (pressTimeMs > windowEnd) return "miss";
   return "success";
 }
 


### PR DESCRIPTION
## Bug

When lowering the parry window slider (e.g. to 700ms with a 1200ms windup), F-presses on reaction to the sound consistently registered as "too early". Slowing down and pressing ~500ms+ later would finally register as a parry.

## Root cause

`parryWindowMs` was being interpreted as a window anchored to the **connect time**:
```
[connectTime - parryWindow, connectTime]
```
So shrinking the window actually shifted the acceptance range *later* — with windup=1200, window=700 the valid range was `[500ms, 1200ms]` after the cue, making normal ~300ms reaction presses count as too early. The default config accidentally worked because `parryWindow === windupDuration`.

## Fix

Redefine `parryWindowMs` as a **reaction deadline from the windup cue**: presses in `[windupStart, windupStart + parryWindowMs]` are valid. This matches the upstream [apxsta/ParryTrainer](https://github.com/apxsta/ParryTrainer) `RESPONSE_TIME` model the comment already referenced.

Tests in `__tests__/deadlock-parry.spec.ts` updated to reflect the corrected semantics. All 19 tests pass; lint clean.