### PR TITLE
Remove unsupported Dependabot review gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,49 +10,19 @@ permissions:
   pull-requests: write
 
 jobs:
-  review-and-enable-auto-merge:
-    name: Copilot review
+  enable-auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'samelliottdlt/website'
     runs-on: ubuntu-latest
-    env:
-      IS_DEPENDABOT: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'samelliottdlt/website' }}
     steps:
-      - name: Skip Copilot review for other pull requests
-        if: env.IS_DEPENDABOT != 'true'
-        run: echo "Copilot review is required only for Dependabot pull requests."
       - name: Fetch Dependabot metadata
-        if: env.IS_DEPENDABOT == 'true'
         id: metadata
         uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Request Copilot review
-        if: env.IS_DEPENDABOT == 'true'
-        run: |
-          if ! gh api "$REVIEWERS_URL" --jq '.users[].login' | grep -Fxq "$COPILOT_REVIEWER"; then
-            gh api --method POST "$REVIEWERS_URL" -f "reviewers[]=$COPILOT_REVIEWER"
-          fi
-        env:
-          COPILOT_REVIEWER: copilot-pull-request-reviewer[bot]
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REVIEWERS_URL: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers
-      - name: Wait for Copilot review
-        if: env.IS_DEPENDABOT == 'true'
-        run: |
-          for attempt in {1..60}; do
-            if gh api "$REVIEWS_URL" --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | .commit_id' | grep -Fxq "$HEAD_SHA"; then
-              exit 0
-            fi
-            sleep 10
-          done
-
-          echo "Copilot did not review commit $HEAD_SHA within 10 minutes." >&2
-          exit 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REVIEWS_URL: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
       - name: Enable auto-merge for minor and patch updates
-        if: env.IS_DEPENDABOT == 'true' && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the Copilot review request and polling gate from Dependabot automation
- retain required dependency review and CI validation
- retain auto-merge only for minor and patch updates

Copilot code review excludes dependency manifests and lockfiles, so pure Dependabot PRs cannot produce the review this gate required. PRs #89 and #90 confirmed the requests time out without a review.

## Validation
- npm run prettier
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run build